### PR TITLE
style: apply prettier formatting to all files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,4 +95,4 @@ Quality gate (must pass before PR):
 - Authority model:
   - Regime Engine is authoritative for “what was planned”
   - Autopilot is authoritative for “what executed” + costs + portfolioAfter
-  - Regime Engine never claims execution happened; only emits REQUEST_* actions
+  - Regime Engine never claims execution happened; only emits REQUEST\_\* actions

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Regime Engine Microservice
 
-Deterministic policy + analytics service for SOL/USDC. This service does not execute trades. It emits REQUEST_* actions, persists truth records, and generates ledger-only weekly reports.
+Deterministic policy + analytics service for SOL/USDC. This service does not execute trades. It emits REQUEST\_\* actions, persists truth records, and generates ledger-only weekly reports.
 
 ## Scope boundary
 
@@ -38,14 +38,19 @@ Server endpoints:
 ## 3-minute local demo
 
 1. Start service:
+
 ```bash
 npm run dev
 ```
+
 2. In a second terminal run harness:
+
 ```bash
 npm run harness -- --fixture ./fixtures/demo --from 2026-01-01 --to 2026-01-31
 ```
+
 3. Inspect artifacts:
+
 - `tmp/reports/weekly-2026-01-01-2026-01-31.md`
 - `tmp/reports/weekly-2026-01-01-2026-01-31.json`
 

--- a/documentation.md
+++ b/documentation.md
@@ -5,7 +5,7 @@ This document is updated continuously as milestones land so it reflects reality.
 ## What Regime Engine is
 
 - A local-first **policy + analytics** microservice that produces deterministic trading plans.
-- It classifies market regime (**UP / DOWN / CHOP**) with hysteresis, applies churn governance, and outputs target exposures (**SOL/USDC bps**) plus **REQUEST_\*** actions for an external execution service.
+- It classifies market regime (**UP / DOWN / CHOP**) with hysteresis, applies churn governance, and outputs target exposures (**SOL/USDC bps**) plus **REQUEST\_\*** actions for an external execution service.
 - It maintains an append-only **truth ledger** of plan requests, plans, and execution results, and can generate weekly reports from the ledger only.
 
 ## What Regime Engine is not
@@ -846,10 +846,10 @@ Remaining risks:
 
 ## One-command demo
 
-1) `npm run dev`
-2) In another terminal:
+1. `npm run dev`
+2. In another terminal:
    - `npm run harness -- --fixture ./fixtures/demo --from 2026-01-01 --to 2026-01-31`
-3) Inspect:
+3. Inspect:
    - `tmp/reports/weekly-*.md`
    - `tmp/reports/weekly-*.json`
 
@@ -906,7 +906,7 @@ Returns weekly report output built from ledger only:
 ### Contract boundary
 
 - Regime Engine produces **policy intent**:
-  - “what should be attempted next” (REQUEST_* actions)
+  - “what should be attempted next” (REQUEST\_\* actions)
   - “what is allowed” (allowClmm)
   - “how aggressively” (targets + caps + constraints)
 - Autopilot produces **execution truth**:
@@ -916,10 +916,10 @@ Returns weekly report output built from ledger only:
 
 ### Typical loop
 
-1) Autopilot gathers candles + its own internal counters/cooldowns and calls `POST /v1/plan`.
-2) Regime Engine returns a Plan (deterministic, hashed).
-3) Autopilot decides whether to execute and then posts `POST /v1/execution-result`.
-4) Regime Engine logs results and reports on outcomes.
+1. Autopilot gathers candles + its own internal counters/cooldowns and calls `POST /v1/plan`.
+2. Regime Engine returns a Plan (deterministic, hashed).
+3. Autopilot decides whether to execute and then posts `POST /v1/execution-result`.
+4. Regime Engine logs results and reports on outcomes.
 
 ## Repo structure overview (target)
 

--- a/implement.md
+++ b/implement.md
@@ -26,21 +26,21 @@ This runbook defines the non-negotiable operating rules for completing the entir
 
 ### Milestone loop (repeat for each milestone)
 
-1) Read: `prompt.md`, `plan.md`, `documentation.md`, `architecture.md`
-2) Identify the first incomplete milestone in `plan.md`
-3) Implement ONLY the scope of that milestone
-4) Add/update tests for the milestone’s core behavior (unit + snapshot where required)
-5) Run milestone verification commands (or full sweep)
-6) If any verification fails:
+1. Read: `prompt.md`, `plan.md`, `documentation.md`, `architecture.md`
+2. Identify the first incomplete milestone in `plan.md`
+3. Implement ONLY the scope of that milestone
+4. Add/update tests for the milestone’s core behavior (unit + snapshot where required)
+5. Run milestone verification commands (or full sweep)
+6. If any verification fails:
    - write/adjust a failing test that reproduces it (where applicable)
    - fix the bug
    - re-run verification until green
    - record a short note in `plan.md` under **Implementation Notes**
-7) Update docs:
+7. Update docs:
    - `documentation.md`: how to run + what changed + known issues
    - `architecture.md`: only if architecture changed
-8) Mark milestone complete in `plan.md`
-9) Commit with a small, reviewable diff
+8. Mark milestone complete in `plan.md`
+9. Commit with a small, reviewable diff
 
 ### Commit discipline
 
@@ -112,6 +112,6 @@ Create and maintain `documentation.md` as a concise operator doc. Keep it update
 
 ## Start procedure
 
-1) Read `plan.md`
-2) Begin Milestone 01
-3) Continue sequentially until final validation sweep passes and completion criteria are satisfied
+1. Read `plan.md`
+2. Begin Milestone 01
+3. Continue sequentially until final validation sweep passes and completion criteria are satisfied

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "vitest": "^3.0.9"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.13.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/plan.md
+++ b/plan.md
@@ -476,7 +476,7 @@ Scope:
 - Produce:
   - `planId` (UUIDv7 recommended)
   - `planHash` (canonical)
-  - `reasons[]`, `telemetry{}` and `actions[]` (REQUEST_* only + HOLD/STAND_DOWN)
+  - `reasons[]`, `telemetry{}` and `actions[]` (REQUEST\_\* only + HOLD/STAND_DOWN)
 
 Key files/modules:
 
@@ -696,23 +696,23 @@ Validation run (2026-03-03):
 
 ## Risk register (top technical risks + mitigations)
 
-1) Regime flip-flop (whipsaw) causing churn
+1. Regime flip-flop (whipsaw) causing churn
 
 - Mitigation: hysteresis + confirmBars + minHoldBars + churn governor stand-down.
 
-2) Hidden non-determinism (key order, float formatting)
+2. Hidden non-determinism (key order, float formatting)
 
 - Mitigation: canonical serializer + snapshot tests + explicit sorts for arrays/maps.
 
-3) Contract drift between microservices
+3. Contract drift between microservices
 
 - Mitigation: schemaVersion + OpenAPI + fixture-based contract tests.
 
-4) Ledger integrity under concurrent requests
+4. Ledger integrity under concurrent requests
 
 - Mitigation: SQLite transactions, deterministic writes, indexed uniqueness where appropriate.
 
-5) Misleading reporting due to external execution authority
+5. Misleading reporting due to external execution authority
 
 - Mitigation: Autopilot is authoritative for portfolioAfter and costs; report separates PLAN vs EXECUTION outcomes.
 
@@ -720,14 +720,14 @@ Validation run (2026-03-03):
 
 ## Demo script (2–3 minutes)
 
-1) Start: `npm run dev`
-2) Health check: `GET /health`
-3) POST `/v1/plan` with CHOP fixture:
+1. Start: `npm run dev`
+2. Health check: `GET /health`
+3. POST `/v1/plan` with CHOP fixture:
    - expect `regime=CHOP`, `allowClmm=true`, targets near neutral
-4) POST `/v1/plan` with DOWN fixture:
+4. POST `/v1/plan` with DOWN fixture:
    - expect `regime=DOWN`, `allowClmm=false`, targets shift USDC-heavy
-5) POST simulated `/v1/execution-result` for both
-6) GET `/v1/report/weekly?from=...&to=...`
+5. POST simulated `/v1/execution-result` for both
+6. GET `/v1/report/weekly?from=...&to=...`
    - show regime distribution, churn/stand-down, costs, baseline comparisons
 
 ---
@@ -737,4 +737,4 @@ Validation run (2026-03-03):
 - Pure engine: indicators -> regime -> churn -> allocation -> chop gate -> plan.
 - Deterministic contract: canonical JSON + planHash.
 - Append-only ledger: requests, plans, results; reporting reads ledger only.
-- Microservice boundary: Regime Engine emits REQUEST_*; Autopilot executes and posts results.
+- Microservice boundary: Regime Engine emits REQUEST\_\*; Autopilot executes and posts results.

--- a/prompt.md
+++ b/prompt.md
@@ -2,7 +2,7 @@
 
 You are Codex acting as a senior staff engineer and tech lead. Implement ONLY the **Regime Engine** microservice for a two-service Solana trading system:
 
-- **Regime Engine (this repo):** policy + analytics. Computes regime (UP/DOWN/CHOP), target exposures (SOL/USDC bps), CLMM allowance gate, churn/stand-down constraints, and emits REQUEST_* actions. Maintains an append-only truth ledger and weekly reports.
+- **Regime Engine (this repo):** policy + analytics. Computes regime (UP/DOWN/CHOP), target exposures (SOL/USDC bps), CLMM allowance gate, churn/stand-down constraints, and emits REQUEST\_\* actions. Maintains an append-only truth ledger and weekly reports.
 - **CLMM Autopilot (other microservice):** execution. Owns all on-chain interactions (Orca/Jupiter/Solana), receipts/idempotency, and posts execution results back to Regime Engine.
 
 This repo MUST NOT contain any on-chain execution adapters or Solana RPC logic beyond integration stubs for contract tests.
@@ -13,7 +13,7 @@ Reference blueprint file: 0
 
 ## One-sentence goal
 
-Given candle history + portfolio state + autopilot counters, produce a deterministic Plan (regime + targets + constraints + REQUEST_* actions) and record a truth ledger suitable for audit-grade performance evaluation and scaling decisions.
+Given candle history + portfolio state + autopilot counters, produce a deterministic Plan (regime + targets + constraints + REQUEST\_\* actions) and record a truth ledger suitable for audit-grade performance evaluation and scaling decisions.
 
 ---
 
@@ -65,7 +65,7 @@ Given candle history + portfolio state + autopilot counters, produce a determini
 
 ### Microservice boundary
 
-- Regime Engine outputs REQUEST_* actions only (never claims execution happened).
+- Regime Engine outputs REQUEST\_\* actions only (never claims execution happened).
 - Autopilot is authoritative for:
   - what executed
   - costs (tx fees/priority/slippage)
@@ -100,7 +100,7 @@ Implement these endpoints:
   - `planId`, `planHash`, `asOfUnixMs`
   - `regime: UP|DOWN|CHOP`
   - `targets: { solBps, usdcBps, allowClmm }`
-  - `actions[]`: REQUEST_* and/or HOLD/STAND_DOWN (no imperative “EXECUTE” semantics)
+  - `actions[]`: REQUEST\_\* and/or HOLD/STAND_DOWN (no imperative “EXECUTE” semantics)
   - `constraints`: cooldowns/budgets + notes
   - `reasons[]`: canonical codes with severity
   - `telemetry`: computed indicator values for inspection
@@ -154,12 +154,12 @@ Generate:
 
 ## Process requirements (follow strictly)
 
-1) Planning first
+1. Planning first
 
 - Ensure `plan.md` exists and matches actual milestones.
 - Do not implement beyond the current milestone.
 
-2) Implement milestone-by-milestone
+2. Implement milestone-by-milestone
    For each milestone:
 
 - implement only the scoped deliverables
@@ -168,7 +168,7 @@ Generate:
 - fix failures immediately
 - update documentation and mark milestone complete
 
-3) Quality gates
+3. Quality gates
 
 - Determinism is a blocker: any non-determinism must be fixed before proceeding.
 - Contract drift is a blocker: OpenAPI and contract fixtures must remain correct.

--- a/scripts/harness.ts
+++ b/scripts/harness.ts
@@ -60,10 +60,7 @@ const loadFixtureSteps = (fixturePath: string): HarnessStepFixture[] => {
   return [JSON.parse(readFileSync(resolvedPath, "utf8")) as HarnessStepFixture];
 };
 
-const toActionResults = (
-  actionTypes: string[],
-  status: "SUCCESS" | "FAILED" | "SKIPPED"
-) => {
+const toActionResults = (actionTypes: string[], status: "SUCCESS" | "FAILED" | "SKIPPED") => {
   if (actionTypes.length === 0) {
     return [
       {
@@ -116,9 +113,7 @@ const main = async (): Promise<void> => {
     });
 
     if (planResponse.statusCode !== 200) {
-      throw new Error(
-        `Plan request failed at step ${index + 1}: ${planResponse.body}`
-      );
+      throw new Error(`Plan request failed at step ${index + 1}: ${planResponse.body}`);
     }
 
     const plan = planResponse.json() as {
@@ -162,9 +157,7 @@ const main = async (): Promise<void> => {
     });
 
     if (executionResponse.statusCode !== 200) {
-      throw new Error(
-        `Execution-result failed at step ${index + 1}: ${executionResponse.body}`
-      );
+      throw new Error(`Execution-result failed at step ${index + 1}: ${executionResponse.body}`);
     }
 
     runSummaries.push({

--- a/src/contract/v1/__tests__/validation.test.ts
+++ b/src/contract/v1/__tests__/validation.test.ts
@@ -1,12 +1,6 @@
 import { describe, expect, it } from "vitest";
-import {
-  ContractValidationError,
-  ERROR_CODES
-} from "../../../http/errors.js";
-import {
-  parseExecutionResultRequest,
-  parsePlanRequest
-} from "../validation.js";
+import { ContractValidationError, ERROR_CODES } from "../../../http/errors.js";
+import { parseExecutionResultRequest, parsePlanRequest } from "../validation.js";
 import { SCHEMA_VERSION, type PlanRequest } from "../types.js";
 
 const validPlanRequestFixture: PlanRequest = {

--- a/src/contract/v1/canonical.ts
+++ b/src/contract/v1/canonical.ts
@@ -36,9 +36,7 @@ const canonicalize = (value: unknown): string => {
 
   if (isPlainObject(value)) {
     const keys = Object.keys(value).sort();
-    const entries = keys.map(
-      (key) => `${JSON.stringify(key)}:${canonicalize(value[key])}`
-    );
+    const entries = keys.map((key) => `${JSON.stringify(key)}:${canonicalize(value[key])}`);
     return `{${entries.join(",")}}`;
   }
 

--- a/src/contract/v1/validation.ts
+++ b/src/contract/v1/validation.ts
@@ -4,11 +4,7 @@ import {
   unsupportedSchemaVersionError,
   validationErrorFromZod
 } from "../../http/errors.js";
-import {
-  SCHEMA_VERSION,
-  type ExecutionResultRequest,
-  type PlanRequest
-} from "./types.js";
+import { SCHEMA_VERSION, type ExecutionResultRequest, type PlanRequest } from "./types.js";
 
 const unixMsSchema = z.number().int().nonnegative();
 const nonNegativeNumberSchema = z.number().nonnegative();
@@ -158,13 +154,8 @@ const executionResultRequestSchema = z
   })
   .strict();
 
-const maybeUnsupportedVersionError = (
-  raw: unknown
-): ContractValidationError | null => {
-  const schemaVersionProbe = z
-    .object({ schemaVersion: z.string() })
-    .passthrough()
-    .safeParse(raw);
+const maybeUnsupportedVersionError = (raw: unknown): ContractValidationError | null => {
+  const schemaVersionProbe = z.object({ schemaVersion: z.string() }).passthrough().safeParse(raw);
 
   if (!schemaVersionProbe.success) {
     return null;
@@ -177,11 +168,7 @@ const maybeUnsupportedVersionError = (
   return unsupportedSchemaVersionError(schemaVersionProbe.data.schemaVersion);
 };
 
-const parseWithSchema = <T>(
-  raw: unknown,
-  schema: z.ZodType<T>,
-  message: string
-): T => {
+const parseWithSchema = <T>(raw: unknown, schema: z.ZodType<T>, message: string): T => {
   const unsupportedVersion = maybeUnsupportedVersionError(raw);
   if (unsupportedVersion) {
     throw unsupportedVersion;
@@ -199,9 +186,7 @@ export const parsePlanRequest = (raw: unknown): PlanRequest => {
   return parseWithSchema(raw, planRequestSchema, "Invalid /v1/plan request body");
 };
 
-export const parseExecutionResultRequest = (
-  raw: unknown
-): ExecutionResultRequest => {
+export const parseExecutionResultRequest = (raw: unknown): ExecutionResultRequest => {
   return parseWithSchema(
     raw,
     executionResultRequestSchema,

--- a/src/engine/allocation/__tests__/volTarget.test.ts
+++ b/src/engine/allocation/__tests__/volTarget.test.ts
@@ -52,8 +52,7 @@ describe("volatility targeting overlay", () => {
       {
         code: "ALLOCATION_CAP_APPLIED",
         severity: "WARN",
-        message:
-          "Exposure change was capped by maxDeltaExposureBpsPerDay/maxTurnoverPerDayBps."
+        message: "Exposure change was capped by maxDeltaExposureBpsPerDay/maxTurnoverPerDayBps."
       }
     ]);
   });

--- a/src/engine/allocation/caps.ts
+++ b/src/engine/allocation/caps.ts
@@ -20,10 +20,7 @@ export const applyExposureCaps = (input: {
 
   const maxStep = Math.max(
     0,
-    Math.min(
-      Math.round(input.maxDeltaExposureBpsPerDay),
-      Math.round(input.maxTurnoverPerDayBps)
-    )
+    Math.min(Math.round(input.maxDeltaExposureBpsPerDay), Math.round(input.maxTurnoverPerDayBps))
   );
 
   const cappedDeltaMagnitude = Math.min(Math.abs(rawDelta), maxStep);

--- a/src/engine/allocation/policy.ts
+++ b/src/engine/allocation/policy.ts
@@ -27,10 +27,7 @@ const clampBps = (value: number): number => {
   return Math.min(10_000, Math.max(0, Math.round(value)));
 };
 
-const desiredByRegime = (
-  regime: Regime,
-  config: AllocationConfig
-): number => {
+const desiredByRegime = (regime: Regime, config: AllocationConfig): number => {
   if (regime === "UP") {
     return config.upSolBps;
   }

--- a/src/engine/allocation/volTarget.ts
+++ b/src/engine/allocation/volTarget.ts
@@ -42,9 +42,7 @@ const computeScale = (regime: Regime, volRatio: number): number => {
   return 1;
 };
 
-export const applyVolatilityTargeting = (
-  input: VolTargetInput
-): VolTargetDecision => {
+export const applyVolatilityTargeting = (input: VolTargetInput): VolTargetDecision => {
   const scale = computeScale(input.regime, input.volRatio);
   const neutralSolBps = 5_000;
   const tilt = input.targetSolBps - neutralSolBps;
@@ -62,8 +60,7 @@ export const applyVolatilityTargeting = (
     reasons.push({
       code: "ALLOCATION_CAP_APPLIED",
       severity: "WARN",
-      message:
-        "Exposure change was capped by maxDeltaExposureBpsPerDay/maxTurnoverPerDayBps."
+      message: "Exposure change was capped by maxDeltaExposureBpsPerDay/maxTurnoverPerDayBps."
     });
   }
 

--- a/src/engine/churn/__tests__/churn.test.ts
+++ b/src/engine/churn/__tests__/churn.test.ts
@@ -48,9 +48,7 @@ describe("churn governor", () => {
     expect(decision.shouldStandDown).toBe(true);
     expect(decision.action).toBe("STAND_DOWN");
     expect(decision.constraints.standDownUntilUnixMs).toBe(AS_OF + 1_000);
-    expect(decision.reasons.some((item) => item.code === "CHURN_COOLDOWN_ACTIVE")).toBe(
-      true
-    );
+    expect(decision.reasons.some((item) => item.code === "CHURN_COOLDOWN_ACTIVE")).toBe(true);
   });
 
   it("anchors stand-down to the existing cooldown expiry mid-window", () => {
@@ -81,11 +79,9 @@ describe("churn governor", () => {
 
     expect(decision.shouldStandDown).toBe(true);
     expect(decision.constraints.stopoutsRemaining).toBe(0);
-    expect(
-      decision.reasons.some(
-        (item) => item.code === "CHURN_STOPOUT_BUDGET_EXCEEDED"
-      )
-    ).toBe(true);
+    expect(decision.reasons.some((item) => item.code === "CHURN_STOPOUT_BUDGET_EXCEEDED")).toBe(
+      true
+    );
   });
 
   it("enters stand-down when two-strike trigger is reached", () => {
@@ -100,11 +96,7 @@ describe("churn governor", () => {
 
     expect(decision.shouldStandDown).toBe(true);
     expect(decision.action).toBe("STAND_DOWN");
-    expect(
-      decision.reasons.some(
-        (item) => item.code === "CHURN_TWO_STRIKE_STAND_DOWN"
-      )
-    ).toBe(true);
+    expect(decision.reasons.some((item) => item.code === "CHURN_TWO_STRIKE_STAND_DOWN")).toBe(true);
   });
 
   it("does not extend stand-down window when only stand-down is active", () => {
@@ -189,12 +181,13 @@ describe("churn governor", () => {
       }
     ];
 
-    const actions = fakeoutSequence.map((state) =>
-      applyChurnGovernor({
-        asOfUnixMs: AS_OF,
-        state,
-        config: churnConfig
-      }).action
+    const actions = fakeoutSequence.map(
+      (state) =>
+        applyChurnGovernor({
+          asOfUnixMs: AS_OF,
+          state,
+          config: churnConfig
+        }).action
     );
 
     expect(actions).toEqual(["HOLD", "HOLD", "STAND_DOWN", "STAND_DOWN"]);

--- a/src/engine/churn/governor.ts
+++ b/src/engine/churn/governor.ts
@@ -34,12 +34,9 @@ export const applyChurnGovernor = (input: {
 
   const cooldownActive = input.state.cooldownUntilUnixMs > input.asOfUnixMs;
   const standDownActive = input.state.standDownUntilUnixMs > input.asOfUnixMs;
-  const stopoutBudgetExceeded =
-    input.state.stopouts24h >= input.config.maxStopouts24h;
-  const redeployBudgetExceeded =
-    input.state.redeploys24h >= input.config.maxRedeploys24h;
-  const strikeTriggered =
-    input.state.strikeCount >= input.config.standDownTriggerStrikes;
+  const stopoutBudgetExceeded = input.state.stopouts24h >= input.config.maxStopouts24h;
+  const redeployBudgetExceeded = input.state.redeploys24h >= input.config.maxRedeploys24h;
+  const strikeTriggered = input.state.strikeCount >= input.config.standDownTriggerStrikes;
 
   if (cooldownActive) {
     reasons.push({
@@ -120,14 +117,8 @@ export const applyChurnGovernor = (input: {
     constraints: {
       cooldownUntilUnixMs: input.state.cooldownUntilUnixMs,
       standDownUntilUnixMs: computedStandDownUntilUnixMs,
-      stopoutsRemaining: clampRemaining(
-        input.config.maxStopouts24h,
-        input.state.stopouts24h
-      ),
-      redeploysRemaining: clampRemaining(
-        input.config.maxRedeploys24h,
-        input.state.redeploys24h
-      ),
+      stopoutsRemaining: clampRemaining(input.config.maxStopouts24h, input.state.stopouts24h),
+      redeploysRemaining: clampRemaining(input.config.maxRedeploys24h, input.state.redeploys24h),
       notes
     },
     reasons

--- a/src/engine/features/candles.ts
+++ b/src/engine/features/candles.ts
@@ -1,8 +1,6 @@
 import type { Candle } from "../../contract/v1/types.js";
 
-export const sortCandlesByUnixMs = (
-  candles: readonly Candle[]
-): Candle[] => {
+export const sortCandlesByUnixMs = (candles: readonly Candle[]): Candle[] => {
   return [...candles].sort((left, right) => left.unixMs - right.unixMs);
 };
 

--- a/src/engine/features/indicators.ts
+++ b/src/engine/features/indicators.ts
@@ -81,7 +81,7 @@ const trendSlope = (values: readonly number[]): number => {
     return 0;
   }
 
-  return (numerator / denominator) / meanY;
+  return numerator / denominator / meanY;
 };
 
 const roundStable = (value: number, digits = 12): number => {
@@ -137,9 +137,7 @@ export const computeIndicators = (
   const volShort = realizedVol(shortReturns);
   const volLong = realizedVol(longReturns);
   const trend = trendSlope(takeLast(closes, merged.trendWindow));
-  const compression = bollingerCompression(
-    takeLast(closes, merged.compressionWindow)
-  );
+  const compression = bollingerCompression(takeLast(closes, merged.compressionWindow));
 
   return {
     realizedVolShort: roundStable(volShort),

--- a/src/engine/plan/__tests__/planDeterminism.snapshot.test.ts
+++ b/src/engine/plan/__tests__/planDeterminism.snapshot.test.ts
@@ -93,9 +93,7 @@ describe("plan determinism", () => {
     });
 
     expect(descendingPlan.regime).toBe(ascendingPlan.regime);
-    expect(descendingPlan.telemetry.currentSolBps).toBe(
-      ascendingPlan.telemetry.currentSolBps
-    );
+    expect(descendingPlan.telemetry.currentSolBps).toBe(ascendingPlan.telemetry.currentSolBps);
     expect(descendingPlan.targets).toEqual(ascendingPlan.targets);
     expect(descendingPlan.actions).toEqual(ascendingPlan.actions);
   });

--- a/src/engine/plan/buildPlan.ts
+++ b/src/engine/plan/buildPlan.ts
@@ -63,10 +63,7 @@ const buildActions = (input: {
   return actions;
 };
 
-export const buildPlan = (
-  request: PlanRequest,
-  regimeState?: RegimeState
-): PlanResponse => {
+export const buildPlan = (request: PlanRequest, regimeState?: RegimeState): PlanResponse => {
   const effectiveRegimeState = regimeState ?? request.regimeState;
   const sortedCandles = sortCandlesByUnixMs(request.market.candles);
   const indicators = computeIndicators(sortedCandles);

--- a/src/engine/regime/classifier.ts
+++ b/src/engine/regime/classifier.ts
@@ -52,11 +52,7 @@ export const classifyRegime = (input: {
   state?: RegimeState;
 }): RegimeDecision => {
   const state = input.state ?? defaultState;
-  const desired = evaluateDesiredRegime(
-    state.current,
-    input.telemetry,
-    input.config
-  );
+  const desired = evaluateDesiredRegime(state.current, input.telemetry, input.config);
 
   if (desired === state.current) {
     return {
@@ -67,9 +63,7 @@ export const classifyRegime = (input: {
         pending: null,
         pendingBars: 0
       },
-      reasons: [
-        reason("REGIME_STABLE", "INFO", `Regime remains ${state.current}.`)
-      ],
+      reasons: [reason("REGIME_STABLE", "INFO", `Regime remains ${state.current}.`)],
       telemetry: input.telemetry
     };
   }

--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -16,8 +16,7 @@ export const ERROR_DETAIL_CODES = {
   UNKNOWN_KEY: "UNKNOWN_KEY"
 } as const;
 
-export type ErrorDetailCode =
-  (typeof ERROR_DETAIL_CODES)[keyof typeof ERROR_DETAIL_CODES];
+export type ErrorDetailCode = (typeof ERROR_DETAIL_CODES)[keyof typeof ERROR_DETAIL_CODES];
 
 export interface ErrorDetail {
   path: string;
@@ -137,9 +136,7 @@ const zodIssueToDetails = (issue: ZodIssue): ErrorDetail[] => {
   ];
 };
 
-export const unsupportedSchemaVersionError = (
-  receivedVersion: string
-): ContractValidationError => {
+export const unsupportedSchemaVersionError = (receivedVersion: string): ContractValidationError => {
   return new ContractValidationError(400, {
     schemaVersion: SCHEMA_VERSION,
     error: {
@@ -160,9 +157,7 @@ export const validationErrorFromZod = (
   message: string,
   issues: ZodIssue[]
 ): ContractValidationError => {
-  const details = stableSortDetails(
-    issues.flatMap((issue) => zodIssueToDetails(issue))
-  );
+  const details = stableSortDetails(issues.flatMap((issue) => zodIssueToDetails(issue)));
 
   return new ContractValidationError(400, {
     schemaVersion: SCHEMA_VERSION,

--- a/src/http/handlers/executionResult.stub.ts
+++ b/src/http/handlers/executionResult.stub.ts
@@ -1,8 +1,5 @@
 import type { FastifyReply, FastifyRequest } from "fastify";
-import {
-  SCHEMA_VERSION,
-  type ExecutionResultResponse
-} from "../../contract/v1/types.js";
+import { SCHEMA_VERSION, type ExecutionResultResponse } from "../../contract/v1/types.js";
 import { type LedgerStore } from "../../ledger/store.js";
 import {
   LEDGER_ERROR_CODES,

--- a/src/http/handlers/executionResult.ts
+++ b/src/http/handlers/executionResult.ts
@@ -1,8 +1,5 @@
 import type { FastifyReply, FastifyRequest } from "fastify";
-import {
-  SCHEMA_VERSION,
-  type ExecutionResultResponse
-} from "../../contract/v1/types.js";
+import { SCHEMA_VERSION, type ExecutionResultResponse } from "../../contract/v1/types.js";
 import { parseExecutionResultRequest } from "../../contract/v1/validation.js";
 import { type LedgerStore } from "../../ledger/store.js";
 import {
@@ -35,8 +32,7 @@ export const createExecutionResultHandler = (store: LedgerStore) => {
       }
 
       if (error instanceof LedgerWriteError) {
-        const statusCode =
-          error.code === LEDGER_ERROR_CODES.PLAN_NOT_FOUND ? 404 : 409;
+        const statusCode = error.code === LEDGER_ERROR_CODES.PLAN_NOT_FOUND ? 404 : 409;
         return reply.code(statusCode).send({
           schemaVersion: SCHEMA_VERSION,
           error: {

--- a/src/http/handlers/plan.stub.ts
+++ b/src/http/handlers/plan.stub.ts
@@ -2,9 +2,7 @@ import type { FastifyReply, FastifyRequest } from "fastify";
 import { planHashFromPlan } from "../../contract/v1/hash.js";
 import { SCHEMA_VERSION, type PlanResponse } from "../../contract/v1/types.js";
 import { parsePlanRequest } from "../../contract/v1/validation.js";
-import {
-  type LedgerStore
-} from "../../ledger/store.js";
+import { type LedgerStore } from "../../ledger/store.js";
 import { writePlanLedgerEntry } from "../../ledger/writer.js";
 import { ContractValidationError } from "../errors.js";
 

--- a/src/http/handlers/report.ts
+++ b/src/http/handlers/report.ts
@@ -1,10 +1,7 @@
 import type { FastifyReply, FastifyRequest } from "fastify";
 import { SCHEMA_VERSION } from "../../contract/v1/types.js";
 import { type LedgerStore } from "../../ledger/store.js";
-import {
-  generateWeeklyReport,
-  ReportRangeError
-} from "../../report/weekly.js";
+import { generateWeeklyReport, ReportRangeError } from "../../report/weekly.js";
 
 const invalidReportRangeResponse = (message: string) => ({
   schemaVersion: SCHEMA_VERSION,
@@ -29,11 +26,11 @@ export const createWeeklyReportHandler = (store: LedgerStore) => {
     const to = request.query.to;
 
     if (!from || !to) {
-      return reply.code(400).send(
-        invalidReportRangeResponse(
-          "Query params from and to are required in YYYY-MM-DD format."
-        )
-      );
+      return reply
+        .code(400)
+        .send(
+          invalidReportRangeResponse("Query params from and to are required in YYYY-MM-DD format.")
+        );
     }
 
     try {

--- a/src/ledger/__tests__/ledger.test.ts
+++ b/src/ledger/__tests__/ledger.test.ts
@@ -251,9 +251,7 @@ describe("ledger writer", () => {
       });
     } catch (error) {
       expect(error).toBeInstanceOf(LedgerWriteError);
-      expect((error as LedgerWriteError).code).toBe(
-        LEDGER_ERROR_CODES.PLAN_NOT_FOUND
-      );
+      expect((error as LedgerWriteError).code).toBe(LEDGER_ERROR_CODES.PLAN_NOT_FOUND);
     }
 
     store.close();

--- a/src/ledger/store.ts
+++ b/src/ledger/store.ts
@@ -30,10 +30,7 @@ export const createLedgerStore = (databasePath: string): LedgerStore => {
   };
 };
 
-export const runInTransaction = <T>(
-  store: LedgerStore,
-  operation: () => T
-): T => {
+export const runInTransaction = <T>(store: LedgerStore, operation: () => T): T => {
   store.db.exec("BEGIN");
   try {
     const result = operation();
@@ -47,17 +44,13 @@ export const runInTransaction = <T>(
 
 export const getLedgerCounts = (store: LedgerStore) => {
   const planRequests =
-    (store.db
-      .prepare("SELECT COUNT(*) AS count FROM plan_requests")
-      .get() as { count: number }).count ?? 0;
+    (store.db.prepare("SELECT COUNT(*) AS count FROM plan_requests").get() as { count: number })
+      .count ?? 0;
   const plans =
-    (store.db
-      .prepare("SELECT COUNT(*) AS count FROM plans")
-      .get() as { count: number }).count ?? 0;
+    (store.db.prepare("SELECT COUNT(*) AS count FROM plans").get() as { count: number }).count ?? 0;
   const executionResults =
-    (store.db
-      .prepare("SELECT COUNT(*) AS count FROM execution_results")
-      .get() as { count: number }).count ?? 0;
+    (store.db.prepare("SELECT COUNT(*) AS count FROM execution_results").get() as { count: number })
+      .count ?? 0;
 
   return {
     planRequests,
@@ -66,10 +59,7 @@ export const getLedgerCounts = (store: LedgerStore) => {
   };
 };
 
-export const findPlanHashByPlanId = (
-  store: LedgerStore,
-  planId: string
-): string | null => {
+export const findPlanHashByPlanId = (store: LedgerStore, planId: string): string | null => {
   const row = store.db
     .prepare("SELECT plan_hash FROM plans WHERE plan_id = ? ORDER BY id DESC LIMIT 1")
     .get(planId) as { plan_hash: string } | undefined;

--- a/src/ledger/writer.ts
+++ b/src/ledger/writer.ts
@@ -1,15 +1,7 @@
 import { toCanonicalJson } from "../contract/v1/canonical.js";
 import { sha256Hex } from "../contract/v1/hash.js";
-import type {
-  ExecutionResultRequest,
-  PlanRequest,
-  PlanResponse
-} from "../contract/v1/types.js";
-import {
-  findPlanHashByPlanId,
-  runInTransaction,
-  type LedgerStore
-} from "./store.js";
+import type { ExecutionResultRequest, PlanRequest, PlanResponse } from "../contract/v1/types.js";
+import { findPlanHashByPlanId, runInTransaction, type LedgerStore } from "./store.js";
 
 export const LEDGER_ERROR_CODES = {
   PLAN_NOT_FOUND: "PLAN_NOT_FOUND",
@@ -85,10 +77,7 @@ export const writeExecutionResultLedgerEntry = (
   }
 ): { inserted: boolean; idempotent: boolean } => {
   const receivedAtUnixMs = input.receivedAtUnixMs ?? Date.now();
-  const storedPlanHash = findPlanHashByPlanId(
-    store,
-    input.executionResult.planId
-  );
+  const storedPlanHash = findPlanHashByPlanId(store, input.executionResult.planId);
 
   if (!storedPlanHash) {
     throw new LedgerWriteError(
@@ -116,10 +105,9 @@ export const writeExecutionResultLedgerEntry = (
         LIMIT 1
       `
     )
-    .get(
-      input.executionResult.planId,
-      input.executionResult.planHash
-    ) as { result_json: string } | undefined;
+    .get(input.executionResult.planId, input.executionResult.planHash) as
+    | { result_json: string }
+    | undefined;
 
   if (existingExecutionResult) {
     if (existingExecutionResult.result_json === canonicalExecutionResult) {

--- a/src/report/__tests__/weeklyReport.snapshot.test.ts
+++ b/src/report/__tests__/weeklyReport.snapshot.test.ts
@@ -5,10 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { buildApp } from "../../app.js";
 import { buildPlan } from "../../engine/plan/buildPlan.js";
 import { createLedgerStore } from "../../ledger/store.js";
-import {
-  writeExecutionResultLedgerEntry,
-  writePlanLedgerEntry
-} from "../../ledger/writer.js";
+import { writeExecutionResultLedgerEntry, writePlanLedgerEntry } from "../../ledger/writer.js";
 import { generateWeeklyReport } from "../weekly.js";
 import type { PlanRequest } from "../../contract/v1/types.js";
 
@@ -21,10 +18,7 @@ afterEach(() => {
   delete process.env.LEDGER_DB_PATH;
 });
 
-const buildRequestFixture = (
-  asOfUnixMs: number,
-  driftPerBar: number
-): PlanRequest => {
+const buildRequestFixture = (asOfUnixMs: number, driftPerBar: number): PlanRequest => {
   return {
     schemaVersion: "1.0",
     asOfUnixMs,
@@ -91,14 +85,8 @@ const buildRequestFixture = (
 describe("weekly report", () => {
   it("generates deterministic ledger-only markdown + JSON snapshots", () => {
     const store = createLedgerStore(":memory:");
-    const firstRequest = buildRequestFixture(
-      Date.parse("2026-01-05T00:00:00.000Z"),
-      0.5
-    );
-    const secondRequest = buildRequestFixture(
-      Date.parse("2026-01-12T00:00:00.000Z"),
-      -0.4
-    );
+    const firstRequest = buildRequestFixture(Date.parse("2026-01-05T00:00:00.000Z"), 0.5);
+    const secondRequest = buildRequestFixture(Date.parse("2026-01-12T00:00:00.000Z"), -0.4);
 
     const firstPlan = buildPlan(firstRequest);
     const secondPlan = buildPlan(secondRequest);

--- a/src/report/baselines.ts
+++ b/src/report/baselines.ts
@@ -56,11 +56,7 @@ const buildPriceSeries = (
     .sort((left, right) => left.unixMs - right.unixMs);
 };
 
-const computeSolHodl = (
-  initialNavUsd: number,
-  firstPrice: number,
-  lastPrice: number
-): number => {
+const computeSolHodl = (initialNavUsd: number, firstPrice: number, lastPrice: number): number => {
   if (firstPrice <= 0) {
     return initialNavUsd;
   }


### PR DESCRIPTION
Fixes #3

Applies `prettier --write .` across 32 files to resolve formatting drift that would red-light CI format checks. No logic changes — pure formatting.