### PR TITLE
feat: add Dockerfile and .dockerignore for production deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+dist
+coverage
+tmp
+*.log
+.git
+.github
+.vscode
+.idea
+*.md
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,15 @@ RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
 
 COPY --from=builder /app/dist ./dist
 
+# Pre-create data directory writable by non-root user
+RUN mkdir -p /app/tmp && chown app:app /app/tmp
+
 USER app
 
 ENV NODE_ENV=production
 ENV PORT=8787
+ENV LEDGER_DB_PATH=tmp/ledger.sqlite
 EXPOSE 8787
 
 # Optionally mount a .env file and load it via --env-file
-CMD ["node", "--env-file=.env", "dist/server.js"]
+CMD ["node", "--env-file=.env", "dist/src/server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,5 @@ ENV NODE_ENV=production
 ENV PORT=8787
 EXPOSE 8787
 
-CMD ["node", "dist/server.js"]
+# Optionally mount a .env file and load it via --env-file
+CMD ["node", "--env-file=.env", "dist/server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,5 +34,6 @@ ENV PORT=8787
 ENV LEDGER_DB_PATH=tmp/ledger.sqlite
 EXPOSE 8787
 
-# Optionally mount a .env file and load it via --env-file
-CMD ["node", "--env-file=.env", "dist/src/server.js"]
+# --env-file-if-exists makes .env optional (won't crash if absent)
+# For deployments that inject env vars directly (Docker -e, K8s env:), no .env is needed.
+CMD ["node", "--env-file-if-exists=.env", "dist/src/server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# ---- Build stage ----
+FROM node:22-slim AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+
+COPY tsconfig.json tsconfig.build.json ./
+COPY src/ src/
+COPY scripts/ scripts/
+
+RUN npm run build
+
+# ---- Production stage ----
+FROM node:22-slim AS production
+
+WORKDIR /app
+
+RUN groupadd --system app && useradd --system --gid app app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
+
+COPY --from=builder /app/dist ./dist
+
+USER app
+
+ENV NODE_ENV=production
+ENV PORT=8787
+EXPOSE 8787
+
+CMD ["node", "dist/server.js"]


### PR DESCRIPTION
Fixes #4

- Multi-stage Dockerfile: build stage compiles TS, production stage copies dist + prod deps only
- Runs as non-root `app` user
- Exposes PORT 8787, defaults NODE_ENV=production
- .dockerignore excludes node_modules, git, temp files, docs