### PR TITLE
docs: add .env.example documenting all runtime env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Regime Engine — Runtime Configuration
+# Copy to .env and adjust values as needed.
+
+# Port the HTTP server listens on
+PORT=8787
+
+# Host binding (0.0.0.0 for all interfaces, 127.0.0.1 for localhost only)
+HOST=0.0.0.0
+
+# SQLite database path for the truth ledger
+# Use ":memory:" for ephemeral/in-memory (useful for testing)
+LEDGER_DB_PATH=tmp/ledger.sqlite
+
+# Node environment: "production" | "development" | "test"
+NODE_ENV=production
+
+# Git commit SHA included in /version responses (optional, useful for deployment tracking)
+# COMMIT_SHA=
+
+# Package version override (defaults to version from package.json)
+# npm_package_version is set automatically by Node when running via npm scripts

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,10 @@
 # Regime Engine — Runtime Configuration
-# Copy to .env and adjust values as needed.
+#
+# This service reads process.env directly (no dotenv dependency).
+# To use this file locally, run with:
+#   node --env-file=.env dist/server.js
+# Or in dev:
+#   npx tsx --env-file=.env src/server.ts
 
 # Port the HTTP server listens on
 PORT=8787

--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,12 @@
 # Regime Engine — Runtime Configuration
 #
 # This service reads process.env directly (no dotenv dependency).
-# To use this file locally, run with:
-#   node --env-file=.env dist/server.js
-# Or in dev:
+#
+# To use this file locally:
 #   npx tsx --env-file=.env src/server.ts
+#
+# In production (Docker), the CMD uses --env-file-if-exists=.env
+# so .env is optional — env vars can also be injected via Docker -e or K8s env:.
 
 # Port the HTTP server listens on
 PORT=8787


### PR DESCRIPTION
Fixes #5

Documents all env vars used by the service:
- `PORT` (default 8787)
- `HOST` (default 0.0.0.0)
- `LEDGER_DB_PATH` (default tmp/ledger.sqlite)
- `NODE_ENV` (default production)
- `COMMIT_SHA` (optional, for /version endpoint)