### PR TITLE
feat: add graceful shutdown on SIGTERM/SIGINT

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import { buildApp } from "./app.js";
 
 const port = Number(process.env.PORT ?? 8787);
 const host = process.env.HOST ?? "0.0.0.0";
+const SHUTDOWN_TIMEOUT_MS = 10_000;
 
 const start = async (): Promise<void> => {
   const app = buildApp();
@@ -11,6 +12,27 @@ const start = async (): Promise<void> => {
     app.log.error(error);
     process.exit(1);
   }
+
+  const gracefulShutdown = async (signal: string): Promise<void> => {
+    app.log.info(`${signal} received, shutting down gracefully`);
+    const forceExit = setTimeout(() => {
+      app.log.error("Forcing exit after shutdown timeout");
+      process.exit(1);
+    }, SHUTDOWN_TIMEOUT_MS);
+    forceExit.unref();
+
+    try {
+      await app.close();
+      app.log.info("Shutdown complete");
+      process.exit(0);
+    } catch (err) {
+      app.log.error(err, "Error during shutdown");
+      process.exit(1);
+    }
+  };
+
+  process.on("SIGTERM", () => void gracefulShutdown("SIGTERM"));
+  process.on("SIGINT", () => void gracefulShutdown("SIGINT"));
 };
 
 void start();


### PR DESCRIPTION
Fixes #12

- Listen for SIGTERM and SIGINT in server.ts
- Call app.close() to drain in-flight requests
- 10s forced-exit timeout fallback
- Log shutdown events

Tested: typecheck, lint, 62/62 tests pass.