### PR TITLE
feat: add Railway deployment config and docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ USER app
 
 ENV NODE_ENV=production
 ENV PORT=8787
-ENV LEDGER_DB_PATH=/data/ledger.sqlite
+ENV LEDGER_DB_PATH=tmp/ledger.sqlite
 EXPOSE 8787
 
 # --env-file-if-exists makes .env optional (won't crash if absent)

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ USER app
 
 ENV NODE_ENV=production
 ENV PORT=8787
-ENV LEDGER_DB_PATH=tmp/ledger.sqlite
+ENV LEDGER_DB_PATH=/data/ledger.sqlite
 EXPOSE 8787
 
 # --env-file-if-exists makes .env optional (won't crash if absent)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ npm run harness -- --fixture ./fixtures/demo --from 2026-01-01 --to 2026-01-31
    |---|---|---|
    | `PORT` | — | Railway sets this automatically |
    | `HOST` | `0.0.0.0` | Host binding |
-   | `LEDGER_DB_PATH` | `/data/ledger.sqlite` | SQLite path — **must point to the volume mount** |
+   | `LEDGER_DB_PATH` | `tmp/ledger.sqlite` | **Override to `/data/ledger.sqlite`** to use the persistent volume |
    | `NODE_ENV` | `production` | Node environment |
    | `COMMIT_SHA` | — | Optional, shown in `/version` |
    | `RAILWAY_RUN_UID` | `0` | **Required** — allows volume writes for non-root container |

--- a/README.md
+++ b/README.md
@@ -58,21 +58,26 @@ npm run harness -- --fixture ./fixtures/demo --from 2026-01-01 --to 2026-01-31
 
 1. Push this repo to a Railway project — Railway detects the `railway.toml` config automatically.
 
-2. Add a **persistent volume**:
+2. Add a **persistent volume** in the Railway service settings:
    - Name: `ledger`
    - Mount path: `/data`
 
-3. Set environment variables in the Railway dashboard (or via `.env` file mounted at `/app/.env`):
+   The `railway.toml` declares `requiredMountPath = "/data"` which will prompt for volume creation on first deploy.
+
+3. Set the `RAILWAY_RUN_UID` environment variable to `0` in the Railway dashboard. The container runs as a non-root user (`app`), but Railway mounts volumes with root ownership. Setting `RAILWAY_RUN_UID=0` ensures the process can write to `/data/ledger.sqlite`.
+
+4. Set environment variables in the Railway dashboard (or via `.env` file mounted at `/app/.env`):
 
    | Variable | Default | Description |
    |---|---|---|
-   | `PORT` | `8787` | HTTP server port (Railway sets this automatically) |
+   | `PORT` | — | Railway sets this automatically |
    | `HOST` | `0.0.0.0` | Host binding |
    | `LEDGER_DB_PATH` | `/data/ledger.sqlite` | SQLite path — **must point to the volume mount** |
    | `NODE_ENV` | `production` | Node environment |
    | `COMMIT_SHA` | — | Optional, shown in `/version` |
+   | `RAILWAY_RUN_UID` | `0` | **Required** — allows volume writes for non-root container |
 
-4. Railway handles HTTPS termination and SIGTERM — the service shuts down gracefully on deploy.
+5. Railway handles HTTPS termination and SIGTERM — the service shuts down gracefully on deploy.
 
 ## Determinism strategy
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,26 @@ npm run harness -- --fixture ./fixtures/demo --from 2026-01-01 --to 2026-01-31
 - `tmp/reports/weekly-2026-01-01-2026-01-31.md`
 - `tmp/reports/weekly-2026-01-01-2026-01-31.json`
 
+## Deploying to Railway
+
+1. Push this repo to a Railway project — Railway detects the `railway.toml` config automatically.
+
+2. Add a **persistent volume**:
+   - Name: `ledger`
+   - Mount path: `/data`
+
+3. Set environment variables in the Railway dashboard (or via `.env` file mounted at `/app/.env`):
+
+   | Variable | Default | Description |
+   |---|---|---|
+   | `PORT` | `8787` | HTTP server port (Railway sets this automatically) |
+   | `HOST` | `0.0.0.0` | Host binding |
+   | `LEDGER_DB_PATH` | `/data/ledger.sqlite` | SQLite path — **must point to the volume mount** |
+   | `NODE_ENV` | `production` | Node environment |
+   | `COMMIT_SHA` | — | Optional, shown in `/version` |
+
+4. Railway handles HTTPS termination and SIGTERM — the service shuts down gracefully on deploy.
+
 ## Determinism strategy
 
 - Canonical JSON with sorted object keys.

--- a/railway.toml
+++ b/railway.toml
@@ -1,5 +1,5 @@
 [build]
-builder = "dockerfile"
+builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile"
 
 [deploy]

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,13 @@
+[build]
+builder = "dockerfile"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+startCommand = "node --env-file-if-exists=.env dist/src/server.js"
+healthcheckPath = "/health"
+healthcheckTimeout = 30
+restartPolicyType = "on_failure"
+
+[[deploy.volume]]
+name = "ledger"
+mountPath = "/data"

--- a/railway.toml
+++ b/railway.toml
@@ -6,8 +6,5 @@ dockerfilePath = "Dockerfile"
 startCommand = "node --env-file-if-exists=.env dist/src/server.js"
 healthcheckPath = "/health"
 healthcheckTimeout = 30
-restartPolicyType = "on_failure"
-
-[[deploy.volume]]
-name = "ledger"
-mountPath = "/data"
+restartPolicyType = "ON_FAILURE"
+requiredMountPath = "/data"


### PR DESCRIPTION
Fixes #11

- `railway.toml`: Dockerfile builder, health check on `/health`, start command with `--env-file-if-exists`, volume mount for persistent SQLite
- README: deploy section with Railway steps, volume setup, env var table
- No changes to src/