### PR TITLE
fix: correct drizzle migration journal timestamp for 0003_create_sr_theses_v2

### DIFF
--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -26,7 +26,7 @@
     {
       "idx": 3,
       "version": "7",
-      "when": 1746009600000,
+      "when": 1777642000000,
       "tag": "0003_create_sr_theses_v2",
       "breakpoints": true
     }


### PR DESCRIPTION
## Problem

The `sr_theses_v2` table was never created in Postgres despite the migration file existing. Railway was crash-looping because `verifySrThesesV2Table()` called `process.exit(1)` at startup.

## Root Cause

The `when` timestamp in `drizzle/meta/_journal.json` for entry idx 3 (`0003_create_sr_theses_v2`) was `1746009600000` (2025-04-30 00:00:00 UTC) — a manually-set round number that predates the timestamps for migrations 0001 and 0002 (both 2026-04-29/30). Drizzle processes entries in journal order and uses the `when` field to determine whether a migration should run. The out-of-order timestamp caused Drizzle to skip the 0003 migration entirely.

## Fix

Updated the `when` field for `0003_create_sr_theses_v2` from `1746009600000` to `1777642000000` (after idx 2's timestamp of `1777555442009`), so the migration runs in correct sequence.

## Validation

```
pnpm run typecheck && pnpm run test && pnpm run lint && pnpm run build
```

All passing: typecheck ✓, 265 tests ✓, lint ✓, build ✓