### PR TITLE
feat: add GeckoTerminal candle collector worker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,16 @@ DATABASE_URL=
 
 # Insight ingest token for CLMM insights API (future #21)
 # INSIGHT_INGEST_TOKEN=
+
+# GeckoTerminal candle collector worker
+REGIME_ENGINE_URL=https://<regime-engine-service>
+CANDLES_INGEST_TOKEN=
+GECKO_SOURCE=geckoterminal
+GECKO_NETWORK=solana
+GECKO_POOL_ADDRESS=<confirm-before-production>
+GECKO_SYMBOL=SOL/USDC
+GECKO_TIMEFRAME=1h
+GECKO_LOOKBACK=200
+GECKO_POLL_INTERVAL_MS=300000
+GECKO_MAX_CALLS_PER_MINUTE=6
+GECKO_REQUEST_TIMEOUT_MS=10000

--- a/README.md
+++ b/README.md
@@ -34,6 +34,46 @@ Server endpoints:
   market-only regime classification + CLMM suitability. Stateless: no
   `RegimeState`, no portfolio/autopilot inputs, no plan-ledger writes.
 
+## GeckoTerminal candle collector
+
+The GeckoTerminal collector is a separate worker service from the same repo. It
+does not start Fastify and does not write SQLite or Postgres directly. It fetches
+the configured Solana SOL/USDC GeckoTerminal pool and posts normalized `1h`
+candles to `POST /v1/candles` with `X-Candles-Ingest-Token`.
+
+Local commands:
+
+```bash
+npm run dev:gecko
+npm run start:gecko
+```
+
+Worker env vars:
+
+| Variable                     | Default         | Notes                                                                     |
+| ---------------------------- | --------------- | ------------------------------------------------------------------------- |
+| `REGIME_ENGINE_URL`          | -               | Absolute URL for the regime-engine web service.                           |
+| `CANDLES_INGEST_TOKEN`       | -               | Shared secret sent as `X-Candles-Ingest-Token`; never commit real values. |
+| `GECKO_SOURCE`               | `geckoterminal` | Must equal `geckoterminal` for MVP.                                       |
+| `GECKO_NETWORK`              | `solana`        | Must equal `solana` for MVP.                                              |
+| `GECKO_POOL_ADDRESS`         | -               | Explicit GeckoTerminal SOL/USDC pool address. Confirm before production.  |
+| `GECKO_SYMBOL`               | `SOL/USDC`      | Must equal `SOL/USDC` for MVP.                                            |
+| `GECKO_TIMEFRAME`            | `1h`            | Must equal `1h` for MVP.                                                  |
+| `GECKO_LOOKBACK`             | `200`           | Rolling candle window size.                                               |
+| `GECKO_POLL_INTERVAL_MS`     | `300000`        | Sleep after each completed cycle.                                         |
+| `GECKO_MAX_CALLS_PER_MINUTE` | `6`             | Provider-scoped GeckoTerminal call cap.                                   |
+| `GECKO_REQUEST_TIMEOUT_MS`   | `10000`         | Per-request timeout for provider and ingest calls.                        |
+
+Railway services from the same repo:
+
+| Service                         | Build        | Start              |
+| ------------------------------- | ------------ | ------------------ |
+| `regime-engine-web`             | `pnpm build` | `pnpm start`       |
+| `regime-engine-gecko-collector` | `pnpm build` | `pnpm start:gecko` |
+
+Production setup and pool confirmation live in
+`docs/runbooks/railway-deploy.md`.
+
 ## Commands
 
 - `npm run dev`

--- a/docs/runbooks/railway-deploy.md
+++ b/docs/runbooks/railway-deploy.md
@@ -200,3 +200,62 @@ Postgres migrations are managed by Drizzle Kit via `npm run db:migrate` (the `pr
 If a deploy introduces a bad migration, the fix is forward — ship a new deploy that adds a
 compensating migration. Do NOT delete the volume. Do NOT manually modify the
 `regime_engine.regime_engine_migrations` table.
+
+## GeckoTerminal collector Railway service
+
+Create a second service from the same repo:
+
+| Setting       | Value                           |
+| ------------- | ------------------------------- |
+| Service name  | `regime-engine-gecko-collector` |
+| Build command | `pnpm build`                    |
+| Start command | `pnpm start:gecko`              |
+
+Do not change `railway.toml` for the collector. The web service continues to use
+`pnpm start`; the collector uses a Railway service start-command override.
+
+Collector env vars:
+
+| Variable                     | Value                                                 |
+| ---------------------------- | ----------------------------------------------------- |
+| `REGIME_ENGINE_URL`          | Railway private or public URL for `regime-engine-web` |
+| `CANDLES_INGEST_TOKEN`       | same value as web service `CANDLES_INGEST_TOKEN`      |
+| `GECKO_SOURCE`               | `geckoterminal`                                       |
+| `GECKO_NETWORK`              | `solana`                                              |
+| `GECKO_POOL_ADDRESS`         | confirmed GeckoTerminal SOL/USDC pool address         |
+| `GECKO_SYMBOL`               | `SOL/USDC`                                            |
+| `GECKO_TIMEFRAME`            | `1h`                                                  |
+| `GECKO_LOOKBACK`             | `200`                                                 |
+| `GECKO_POLL_INTERVAL_MS`     | `300000`                                              |
+| `GECKO_MAX_CALLS_PER_MINUTE` | `6`                                                   |
+| `GECKO_REQUEST_TIMEOUT_MS`   | `10000`                                               |
+
+URL notes:
+
+- Public `REGIME_ENGINE_URL` values must use HTTPS.
+- Plain HTTP is accepted only for `localhost`, `127.0.0.1`, `::1`, or Railway
+  private `*.railway.internal` hosts.
+- The collector posts to `new URL("/v1/candles", REGIME_ENGINE_URL)`, which
+  targets the origin root. Do not configure a base URL that relies on a path
+  prefix.
+
+Pool preflight:
+
+```bash
+curl -fsS "https://api.geckoterminal.com/api/v2/networks/solana/pools/$GECKO_POOL_ADDRESS/ohlcv/hour?aggregate=1&limit=1"
+```
+
+Before production:
+
+- [ ] Confirm and record the canonical GeckoTerminal Solana SOL/USDC pool address.
+- [ ] Confirm the collector can reach `REGIME_ENGINE_URL`.
+- [ ] Confirm the web service and collector share the same `CANDLES_INGEST_TOKEN`.
+
+Token management:
+
+1. Generate a new `CANDLES_INGEST_TOKEN` in the password manager.
+2. Update the web service token and collector service token in the same Railway
+   maintenance window.
+3. Restart the web service, then restart the collector service.
+4. Confirm collector logs show successful ingest after rotation.
+5. Treat suspected token exposure as a same-day rotation event.

--- a/docs/solutions/developer-experience/typescript-strict-tooling-friction-patterns-2026-05-01.md
+++ b/docs/solutions/developer-experience/typescript-strict-tooling-friction-patterns-2026-05-01.md
@@ -1,0 +1,144 @@
+---
+title: TypeScript Strict Mode and ESLint Zero-Tolerance Friction Patterns
+date: 2026-05-01
+category: developer-experience
+module: src/workers/gecko
+problem_type: developer_experience
+component: tooling
+severity: medium
+applies_when:
+  - Adding modules that consume external API JSON with unknown payloads
+  - Writing test mocks for injected logger/service interfaces under zero-tolerance lint
+  - Implementing callbacks or retry functions where some args aren't used
+  - Creating test fixtures for code with threshold/guard logic
+  - Working with AbortSignal in tests
+tags:
+  [
+    typescript,
+    strict-mode,
+    type-guards,
+    eslint,
+    no-explicit-any,
+    no-unused-vars,
+    import-resolution,
+    test-fixtures,
+    abort-controller
+  ]
+---
+
+# TypeScript Strict Mode and ESLint Zero-Tolerance Friction Patterns
+
+## Context
+
+While implementing the GeckoTerminal Candle Collector worker for regime-engine, several recurring TypeScript and ESLint patterns caused build and lint failures. These issues are non-obvious, often only surface at typecheck or lint time (not in IDE autocomplete), and tend to cascade — a single `unknown` payload or wrong import path can produce 5-10 downstream type errors. This guidance captures the solutions as reusable patterns for any project using `@typescript-eslint/recommended` with zero-tolerance lint (`--max-warnings 0`).
+
+## Guidance
+
+### 1. Type-Safe Narrowing of `unknown` API Payloads
+
+When consuming external APIs, response payloads arrive as `unknown`. Casting with `as Record<string, unknown>` and then accessing nested properties fails typecheck because TypeScript still sees the base type as `unknown`.
+
+**Fix:** Introduce type guard functions:
+
+```typescript
+function isObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+// Usage — chain guards for nested access:
+if (!isObject(payload) || !isObject(payload.data) || !isObject(payload.data.attributes)) {
+  throw new ProtocolError("Invalid envelope");
+}
+const ohlcvList = payload.data.attributes.ohlcv_list;
+```
+
+### 2. Avoid `as any` for Test Mocks — Use Interface Types
+
+`@typescript-eslint/no-explicit-any` (enabled in `recommended`) rejects `as any` casts. For mock objects in tests, import the interface and cast to that type instead.
+
+```typescript
+// Before (broken):
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as any;
+
+// After (fixed):
+import type { WorkerLogger } from "./logger.js";
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as WorkerLogger;
+```
+
+### 3. `@typescript-eslint/no-unused-vars` Doesn't Honor Underscore Prefix
+
+Unlike vanilla ESLint's `no-unused-vars`, the TypeScript variant under `@typescript-eslint/recommended` does **not** ignore `_`-prefixed parameters. Solutions:
+
+- **Remove unused parameters entirely** when possible (e.g., drop the second arg from `nonNegativeInteger`).
+- **Type assertion for callback signatures** that must accept but don't use args:
+
+```typescript
+// Before (broken): _attempt triggers no-unused-vars
+(attempt) =>
+  fetchGeckoOhlcv(
+    config,
+    deps
+  )(
+    // After (fixed): type assertion on the implementation
+    () => fetchGeckoOhlcv(config, deps)
+  ) as (attempt: number) => Promise<unknown>;
+```
+
+- Or configure the ESLint rule with `"argsIgnorePattern": "^_"` if the project prefers keeping params for documentation.
+
+### 4. Verify Relative Import Paths at Typecheck Time
+
+IDEs may not catch wrong relative paths. A common mistake: counting `../` segments incorrectly for nested files. From `src/workers/geckoCollector.ts`, `../../contract/v1/types.js` resolves _above_ `src/` — the correct path is `../contract/v1/types.js`.
+
+Always run `pnpm run typecheck` after adding new imports.
+
+### 5. Align Test Fixtures with Business Logic Guards
+
+When production code has threshold guards (e.g., "block ingest if `lookback >= 50` and `validCount < 50`"), test data must satisfy those guards or tests silently skip the code under test. The `shouldPostNormalizedBatch` guard blocked all happy-path tests when `geckoLookback` was 200 but only 1 valid candle was provided.
+
+**Fix:** Use realistic fixture data or adjust test config defaults to match the test scenario:
+
+```typescript
+// Test config with lookback below threshold:
+const BASE_CONFIG = { geckoLookback: 10, ... };
+```
+
+### 6. Don't Mutate `AbortSignal.aborted` — Use `AbortController`
+
+`AbortSignal.aborted` is a readonly property. Assigning to it throws in strict mode.
+
+```typescript
+// Before (broken):
+const signal = AbortSignal.abort; // or: signal.aborted = true; ← runtime error
+
+// After (fixed):
+const controller = new AbortController();
+controller.abort();
+const signal = controller.signal; // signal.aborted === true
+```
+
+### 7. Remove All Unused Imports/Exports Under Zero-Tolerance Lint
+
+With `@typescript-eslint/no-unused-vars` set to error with no exceptions, every unused import, unused export, unused destructured variable, and unused function parameter is a lint failure. Remove them proactively — this includes type-only imports used only in tests, helper functions never called, and destructured fields not referenced.
+
+## Why This Matters
+
+- **CI gate is real**: `pnpm run typecheck && pnpm run test && pnpm run lint && pnpm run build` must all pass. Any one of these patterns blocks PRs.
+- **Feedback loop is slow**: These failures often don't surface in IDE autocomplete — they only appear at typecheck/lint time.
+- **Cascade effect**: A single `unknown` payload or wrong import path can produce 5-10 downstream type errors, masking the root cause.
+- **Silent test vacuum**: Test data that doesn't satisfy business guards doesn't fail — it silently exercises no meaningful code path, creating false confidence.
+
+## When to Apply
+
+- Adding a new module that consumes external API JSON (`unknown` payloads)
+- Writing test mocks for injected logger/service interfaces
+- Implementing callbacks or retry functions where some args aren't used
+- Adding imports from another module — always typecheck after
+- Creating test fixtures for code that has threshold/guard logic
+- Writing tests involving `AbortSignal` or `AbortController`
+- Working in a project with `@typescript-eslint/recommended` or stricter config
+
+## Related
+
+- GitHub Issue #18: GeckoTerminal candle collector feature
+- `docs/solutions/developer-experience/pg-dependent-route-test-isolation-2026-04-30.md` — related DX friction (test isolation), different problem space

--- a/docs/superpowers/plans/2026-05-01-gecko-terminal-collector.md
+++ b/docs/superpowers/plans/2026-05-01-gecko-terminal-collector.md
@@ -118,6 +118,23 @@ describe("parseGeckoCollectorConfig", () => {
     ).toThrow("REGIME_ENGINE_URL");
   });
 
+  it("rejects plain HTTP except localhost and Railway private hosts", () => {
+    expect(() =>
+      parseGeckoCollectorConfig({ ...validEnv, REGIME_ENGINE_URL: "http://example.com" })
+    ).toThrow("REGIME_ENGINE_URL");
+
+    expect(
+      parseGeckoCollectorConfig({ ...validEnv, REGIME_ENGINE_URL: "http://localhost:8787" })
+        .regimeEngineUrl.href
+    ).toBe("http://localhost:8787/");
+    expect(
+      parseGeckoCollectorConfig({
+        ...validEnv,
+        REGIME_ENGINE_URL: "http://regime-engine.railway.internal:8787"
+      }).regimeEngineUrl.href
+    ).toBe("http://regime-engine.railway.internal:8787/");
+  });
+
   it.each([
     ["GECKO_SOURCE", "other"],
     ["GECKO_NETWORK", "ethereum"],
@@ -126,6 +143,13 @@ describe("parseGeckoCollectorConfig", () => {
   ])("rejects unsupported MVP value %s=%s", (key, value) => {
     expect(() => parseGeckoCollectorConfig({ ...validEnv, [key]: value })).toThrow(key);
   });
+
+  it.each(["GECKO_SOURCE", "GECKO_LOOKBACK", "GECKO_SYMBOL"])(
+    "rejects explicit empty optional env %s",
+    (key) => {
+      expect(() => parseGeckoCollectorConfig({ ...validEnv, [key]: "" })).toThrow(key);
+    }
+  );
 
   it.each([
     ["GECKO_LOOKBACK", "0"],
@@ -177,13 +201,24 @@ const readRequired = (env: NodeJS.ProcessEnv, key: string): string => {
   return value;
 };
 
+const readOptional = (env: NodeJS.ProcessEnv, key: string, defaultValue: string): string => {
+  if (!(key in env)) {
+    return defaultValue;
+  }
+  const value = env[key]?.trim();
+  if (!value) {
+    throw new Error(`${key} must not be empty`);
+  }
+  return value;
+};
+
 const readLiteral = <T extends string>(
   env: NodeJS.ProcessEnv,
   key: string,
   defaultValue: T,
   allowed: T
 ): T => {
-  const value = (env[key]?.trim() || defaultValue) as T;
+  const value = readOptional(env, key, defaultValue) as T;
   if (value !== allowed) {
     throw new Error(`${key} must equal ${allowed}`);
   }
@@ -191,12 +226,22 @@ const readLiteral = <T extends string>(
 };
 
 const readPositiveInteger = (env: NodeJS.ProcessEnv, key: string, defaultValue: number): number => {
-  const raw = env[key]?.trim() || String(defaultValue);
+  const raw = readOptional(env, key, String(defaultValue));
   const parsed = Number(raw);
   if (!Number.isInteger(parsed) || parsed <= 0) {
     throw new Error(`${key} must be a positive integer`);
   }
   return parsed;
+};
+
+const isAllowedHttpHost = (hostname: string): boolean => {
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname === "[::1]" ||
+    hostname.endsWith(".railway.internal")
+  );
 };
 
 const readAbsoluteUrl = (env: NodeJS.ProcessEnv, key: string): URL => {
@@ -206,9 +251,17 @@ const readAbsoluteUrl = (env: NodeJS.ProcessEnv, key: string): URL => {
     if (!url.protocol || !url.hostname) {
       throw new Error("missing protocol or host");
     }
+    if (url.protocol === "http:" && !isAllowedHttpHost(url.hostname)) {
+      throw new Error("plain HTTP is only allowed for localhost or Railway private hosts");
+    }
+    if (url.protocol !== "https:" && url.protocol !== "http:") {
+      throw new Error("unsupported protocol");
+    }
     return url;
   } catch {
-    throw new Error(`${key} must be an absolute URL`);
+    throw new Error(
+      `${key} must be an absolute HTTPS URL, localhost HTTP URL, or Railway private HTTP URL`
+    );
   }
 };
 
@@ -244,22 +297,29 @@ export type WorkerLogger = {
   error: (event: string, context?: LogContext) => void;
 };
 
-const SECRET_KEYS = new Set([
-  "candlesIngestToken",
-  "CANDLES_INGEST_TOKEN",
-  "x-candles-ingest-token"
-]);
+const SECRET_KEY_PATTERN = /(token|secret|authorization|headers|responseBody)/i;
+
+const redactValue = (key: string, value: unknown): unknown => {
+  if (SECRET_KEY_PATTERN.test(key)) {
+    return "[REDACTED]";
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactValue("", item));
+  }
+  if (typeof value === "object" && value !== null) {
+    const nested: LogContext = {};
+    for (const [nestedKey, nestedValue] of Object.entries(value)) {
+      nested[nestedKey] = redactValue(nestedKey, nestedValue);
+    }
+    return nested;
+  }
+  return value;
+};
 
 export const redactLogContext = (context: LogContext = {}): LogContext => {
   const redacted: LogContext = {};
   for (const [key, value] of Object.entries(context)) {
-    if (SECRET_KEYS.has(key) || key.toLowerCase().includes("token")) {
-      redacted[key] = "[REDACTED]";
-    } else if (key.toLowerCase() === "headers") {
-      redacted[key] = "[REDACTED]";
-    } else {
-      redacted[key] = value;
-    }
+    redacted[key] = redactValue(key, value);
   }
   return redacted;
 };
@@ -453,6 +513,30 @@ describe("withRetry", () => {
     expect(operation).toHaveBeenCalledTimes(2);
   });
 
+  it("exits promptly when retry backoff sleep is aborted", async () => {
+    const abort = new AbortController();
+    const originalError = new HttpError({ statusCode: 503, retryable: true });
+    const operation = vi.fn(async () => {
+      throw originalError;
+    });
+    const sleep = vi.fn(async (_ms: number, _options?: { signal?: AbortSignal }) => {
+      abort.abort();
+      throw new DOMException("aborted", "AbortError");
+    });
+
+    await expect(
+      withRetry(operation, {
+        maxAttempts: 3,
+        initialBackoffMs: 1000,
+        maxBackoffMs: 30000,
+        jitterMs: () => 0,
+        sleep,
+        signal: abort.signal
+      })
+    ).rejects.toBe(originalError);
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
   it("stops before another attempt when shouldContinue returns false", async () => {
     const operation = vi.fn(async () => {
       throw new HttpError({ statusCode: 503, retryable: true });
@@ -481,6 +565,8 @@ describe("createRateLimiter", () => {
     const waitForPermit = createRateLimiter(6, { sleep, now: () => now });
 
     await waitForPermit();
+    expect(sleep).not.toHaveBeenCalled();
+
     await waitForPermit();
     await waitForPermit();
 
@@ -554,7 +640,8 @@ export type RetryOptions = {
   initialBackoffMs: number;
   maxBackoffMs: number;
   jitterMs: (attempt: number) => number;
-  sleep: (ms: number) => Promise<unknown>;
+  sleep: (ms: number, options?: { signal?: AbortSignal }) => Promise<unknown>;
+  signal?: AbortSignal;
   shouldContinue?: () => boolean;
 };
 
@@ -590,7 +677,17 @@ export async function withRetry<T>(
 
       const exponential = options.initialBackoffMs * 2 ** (attempt - 1);
       const capped = Math.min(options.maxBackoffMs, exponential);
-      await options.sleep(capped + options.jitterMs(attempt));
+      try {
+        await options.sleep(capped + options.jitterMs(attempt), { signal: options.signal });
+      } catch (sleepError) {
+        if (
+          sleepError instanceof DOMException &&
+          (sleepError.name === "AbortError" || sleepError.name === "TimeoutError")
+        ) {
+          throw error;
+        }
+        throw sleepError;
+      }
 
       if (options.shouldContinue && !options.shouldContinue()) {
         throw error;
@@ -698,6 +795,19 @@ describe("normalizeGeckoOhlcv", () => {
     expect(() => normalizeGeckoOhlcv({ data: { attributes: {} } }, config)).toThrow("ohlcv_list");
   });
 
+  it("throws ProtocolError when provider returns more than 1000 rows", () => {
+    const rows = Array.from({ length: 1001 }, (_, index) => [
+      (index + 1) * 3600,
+      100,
+      110,
+      90,
+      105,
+      1
+    ]);
+
+    expect(() => normalizeGeckoOhlcv(payload(rows), config)).toThrow("1000");
+  });
+
   it("drops non-array rows and rows with missing or extra fields", () => {
     const result = normalizeGeckoOhlcv(
       payload([
@@ -729,6 +839,16 @@ describe("normalizeGeckoOhlcv", () => {
     expect(result.validCandles.map((candle) => candle.unixMs)).toEqual([14_400_000]);
     expect(result.stats.misalignedRowCount).toBe(1);
     expect(result.stats.invalidOhlcvRowCount).toBe(3);
+  });
+
+  it("drops unsafe timestamp rows as malformed", () => {
+    const result = normalizeGeckoOhlcv(
+      payload([[Number.MAX_SAFE_INTEGER + 1, 100, 110, 90, 105, 1]]),
+      config
+    );
+
+    expect(result.validCandles).toEqual([]);
+    expect(result.stats.malformedRowCount).toBe(1);
   });
 
   it("dedupes identical rows without adding to corruption dropped count", () => {
@@ -928,6 +1048,9 @@ const readRows = (payload: unknown): unknown[] => {
   ) {
     throw new ProtocolError("GeckoTerminal payload missing data.attributes.ohlcv_list array");
   }
+  if (payload.data.attributes.ohlcv_list.length > 1000) {
+    throw new ProtocolError("GeckoTerminal ohlcv_list must not exceed 1000 rows");
+  }
   return payload.data.attributes.ohlcv_list;
 };
 
@@ -944,7 +1067,14 @@ const toFiniteNumber = (value: unknown): number | null => {
   return value;
 };
 
-const parseRow = (row: unknown, stats: NormalizationStats): Candle | null => {
+const timeframeMsForConfig = (config: GeckoCollectorConfig): number => {
+  if (config.geckoTimeframe !== "1h") {
+    throw new ProtocolError("Only GECKO_TIMEFRAME=1h is supported");
+  }
+  return ONE_HOUR_MS;
+};
+
+const parseRow = (row: unknown, stats: NormalizationStats, timeframeMs: number): Candle | null => {
   if (!Array.isArray(row) || row.length !== 6) {
     stats.malformedRowCount += 1;
     increment(stats, "malformed");
@@ -966,7 +1096,8 @@ const parseRow = (row: unknown, stats: NormalizationStats): Candle | null => {
     low === null ||
     close === null ||
     volume === null ||
-    !Number.isInteger(timestampSeconds)
+    !Number.isInteger(timestampSeconds) ||
+    !Number.isSafeInteger(timestampSeconds)
   ) {
     stats.malformedRowCount += 1;
     increment(stats, "malformed");
@@ -974,7 +1105,13 @@ const parseRow = (row: unknown, stats: NormalizationStats): Candle | null => {
   }
 
   const unixMs = timestampSeconds * 1000;
-  if (!Number.isInteger(unixMs) || unixMs % ONE_HOUR_MS !== 0) {
+  if (!Number.isSafeInteger(unixMs)) {
+    stats.malformedRowCount += 1;
+    increment(stats, "malformed");
+    return null;
+  }
+
+  if (!Number.isInteger(unixMs) || unixMs % timeframeMs !== 0) {
     stats.misalignedRowCount += 1;
     increment(stats, "misaligned");
     return null;
@@ -999,15 +1136,16 @@ const parseRow = (row: unknown, stats: NormalizationStats): Candle | null => {
 
 export function normalizeGeckoOhlcv(
   payload: unknown,
-  _config: GeckoCollectorConfig
+  config: GeckoCollectorConfig
 ): NormalizationResult {
   const rows = readRows(payload);
+  const timeframeMs = timeframeMsForConfig(config);
   const stats = emptyStats();
   stats.providerRowCount = rows.length;
 
   const groups = new Map<number, Candle[]>();
   for (const row of rows) {
-    const candle = parseRow(row, stats);
+    const candle = parseRow(row, stats, timeframeMs);
     if (!candle) continue;
     const existing = groups.get(candle.unixMs) ?? [];
     existing.push(candle);
@@ -1125,8 +1263,7 @@ describe("fetchGeckoOhlcv", () => {
 
     await fetchGeckoOhlcv(config, {
       fetch: fetchMock,
-      waitForProviderPermit,
-      createTimeoutSignal: () => undefined
+      waitForProviderPermit
     });
 
     expect(waitForProviderPermit).toHaveBeenCalledTimes(1);
@@ -1144,8 +1281,7 @@ describe("fetchGeckoOhlcv", () => {
       await expect(
         fetchGeckoOhlcv(config, {
           fetch: fetchMock,
-          waitForProviderPermit: async () => {},
-          createTimeoutSignal: () => undefined
+          waitForProviderPermit: async () => {}
         })
       ).rejects.toMatchObject({ statusCode: status, retryable: true });
     }
@@ -1157,8 +1293,7 @@ describe("fetchGeckoOhlcv", () => {
     await expect(
       fetchGeckoOhlcv(config, {
         fetch: fetchMock,
-        waitForProviderPermit: async () => {},
-        createTimeoutSignal: () => undefined
+        waitForProviderPermit: async () => {}
       })
     ).rejects.toMatchObject({ statusCode: 404, retryable: false });
   });
@@ -1169,8 +1304,24 @@ describe("fetchGeckoOhlcv", () => {
     await expect(
       fetchGeckoOhlcv(config, {
         fetch: fetchMock,
-        waitForProviderPermit: async () => {},
-        createTimeoutSignal: () => undefined
+        waitForProviderPermit: async () => {}
+      })
+    ).rejects.toBeInstanceOf(ProtocolError);
+  });
+
+  it("throws ProtocolError for oversized 2xx response bodies", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response("{}", {
+          status: 200,
+          headers: { "content-length": String(512 * 1024 + 1) }
+        })
+    );
+
+    await expect(
+      fetchGeckoOhlcv(config, {
+        fetch: fetchMock,
+        waitForProviderPermit: async () => {}
       })
     ).rejects.toBeInstanceOf(ProtocolError);
   });
@@ -1184,8 +1335,7 @@ describe("fetchGeckoOhlcv", () => {
     await expect(
       fetchGeckoOhlcv(config, {
         fetch: fetchMock,
-        waitForProviderPermit: async () => {},
-        createTimeoutSignal: () => undefined
+        waitForProviderPermit: async () => {}
       })
     ).rejects.toBeInstanceOf(RequestTimeoutError);
   });
@@ -1198,8 +1348,7 @@ describe("fetchGeckoOhlcv", () => {
     await expect(
       fetchGeckoOhlcv(config, {
         fetch: fetchMock,
-        waitForProviderPermit: async () => {},
-        createTimeoutSignal: () => undefined
+        waitForProviderPermit: async () => {}
       })
     ).rejects.toBeInstanceOf(RequestTransportError);
   });
@@ -1235,7 +1384,6 @@ export type GeckoOhlcvPayload = unknown;
 export type GeckoFetchDeps = {
   fetch?: typeof fetch;
   waitForProviderPermit: () => Promise<void>;
-  createTimeoutSignal?: (timeoutMs: number) => AbortSignal | undefined;
 };
 
 const encodeSegment = (segment: string): string => encodeURIComponent(segment);
@@ -1254,17 +1402,32 @@ const buildGeckoUrl = (config: GeckoCollectorConfig): URL => {
   return url;
 };
 
+const MAX_RESPONSE_BYTES = 512 * 1024;
+
+const readTextWithLimit = async (response: Response): Promise<string> => {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength && Number(contentLength) > MAX_RESPONSE_BYTES) {
+    throw new ProtocolError("Response body exceeds 512 KiB limit");
+  }
+  const text = await response.text();
+  if (text.length > MAX_RESPONSE_BYTES) {
+    throw new ProtocolError("Response body exceeds 512 KiB limit");
+  }
+  return text;
+};
+
 const parseJson = async (response: Response): Promise<unknown> => {
   try {
-    return await response.json();
+    return JSON.parse(await readTextWithLimit(response));
   } catch (error) {
+    if (error instanceof ProtocolError) throw error;
     throw new ProtocolError(
       `GeckoTerminal returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`
     );
   }
 };
 
-const wrapFetchError = (error: unknown): never => {
+function wrapFetchError(error: unknown): never {
   if (
     error instanceof DOMException &&
     (error.name === "AbortError" || error.name === "TimeoutError")
@@ -1275,7 +1438,7 @@ const wrapFetchError = (error: unknown): never => {
     throw new RequestTransportError(error.message);
   }
   throw error;
-};
+}
 
 export async function fetchGeckoOhlcv(
   config: GeckoCollectorConfig,
@@ -1284,9 +1447,7 @@ export async function fetchGeckoOhlcv(
   await deps.waitForProviderPermit();
 
   const fetchImpl = deps.fetch ?? fetch;
-  const signal =
-    deps.createTimeoutSignal?.(config.geckoRequestTimeoutMs) ??
-    AbortSignal.timeout(config.geckoRequestTimeoutMs);
+  const signal = AbortSignal.timeout(config.geckoRequestTimeoutMs);
   let response: Response;
 
   try {
@@ -1301,7 +1462,7 @@ export async function fetchGeckoOhlcv(
   if (!response.ok) {
     throw new HttpError({
       statusCode: response.status,
-      responseBody: await response.text().catch(() => undefined),
+      responseBody: await readTextWithLimit(response).catch(() => undefined),
       retryable: isRetryableHttpStatus(response.status)
     });
   }
@@ -1383,8 +1544,7 @@ describe("postCandles", () => {
     );
 
     const result = await postCandles(config, candles, "2026-05-01T00:00:00.000Z", {
-      fetch: fetchMock,
-      createTimeoutSignal: () => undefined
+      fetch: fetchMock
     });
 
     expect(result.insertedCount).toBe(1);
@@ -1428,8 +1588,7 @@ describe("postCandles", () => {
 
     await expect(
       postCandles(config, candles, "2026-05-01T00:00:00.000Z", {
-        fetch: fetchMock,
-        createTimeoutSignal: () => undefined
+        fetch: fetchMock
       })
     ).resolves.toMatchObject({ rejectedCount: 1 });
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -1440,8 +1599,7 @@ describe("postCandles", () => {
       const fetchMock = vi.fn(async () => new Response("error", { status }));
       await expect(
         postCandles(config, candles, "2026-05-01T00:00:00.000Z", {
-          fetch: fetchMock,
-          createTimeoutSignal: () => undefined
+          fetch: fetchMock
         })
       ).rejects.toMatchObject({ statusCode: status, retryable: true });
     }
@@ -1451,8 +1609,7 @@ describe("postCandles", () => {
     const fetchMock = vi.fn(async () => new Response("bad token", { status: 401 }));
     await expect(
       postCandles(config, candles, "2026-05-01T00:00:00.000Z", {
-        fetch: fetchMock,
-        createTimeoutSignal: () => undefined
+        fetch: fetchMock
       })
     ).rejects.toMatchObject({ statusCode: 401, retryable: false });
   });
@@ -1464,8 +1621,7 @@ describe("postCandles", () => {
     );
     await expect(
       postCandles(config, candles, "2026-05-01T00:00:00.000Z", {
-        fetch: fetchMock,
-        createTimeoutSignal: () => undefined
+        fetch: fetchMock
       })
     ).rejects.toBeInstanceOf(ProtocolError);
   });
@@ -1479,8 +1635,23 @@ describe("postCandles", () => {
     );
     await expect(
       postCandles(config, candles, "2026-05-01T00:00:00.000Z", {
-        fetch: fetchMock,
-        createTimeoutSignal: () => undefined
+        fetch: fetchMock
+      })
+    ).rejects.toBeInstanceOf(ProtocolError);
+  });
+
+  it("throws ProtocolError for oversized 2xx response bodies", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response("{}", {
+          status: 200,
+          headers: { "content-length": String(512 * 1024 + 1) }
+        })
+    );
+
+    await expect(
+      postCandles(config, candles, "2026-05-01T00:00:00.000Z", {
+        fetch: fetchMock
       })
     ).rejects.toBeInstanceOf(ProtocolError);
   });
@@ -1514,11 +1685,24 @@ import {
 
 export type IngestClientDeps = {
   fetch?: typeof fetch;
-  createTimeoutSignal?: (timeoutMs: number) => AbortSignal | undefined;
 };
 
 const nonNegativeInteger = (value: unknown): value is number => {
   return typeof value === "number" && Number.isInteger(value) && value >= 0;
+};
+
+const MAX_RESPONSE_BYTES = 512 * 1024;
+
+const readTextWithLimit = async (response: Response): Promise<string> => {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength && Number(contentLength) > MAX_RESPONSE_BYTES) {
+    throw new ProtocolError("Response body exceeds 512 KiB limit");
+  }
+  const text = await response.text();
+  if (text.length > MAX_RESPONSE_BYTES) {
+    throw new ProtocolError("Response body exceeds 512 KiB limit");
+  }
+  return text;
 };
 
 const validateResponse = (body: unknown): CandleIngestResponse => {
@@ -1551,7 +1735,7 @@ const validateResponse = (body: unknown): CandleIngestResponse => {
   return body as CandleIngestResponse;
 };
 
-const wrapFetchError = (error: unknown): never => {
+function wrapFetchError(error: unknown): never {
   if (
     error instanceof DOMException &&
     (error.name === "AbortError" || error.name === "TimeoutError")
@@ -1562,7 +1746,7 @@ const wrapFetchError = (error: unknown): never => {
     throw new RequestTransportError(error.message);
   }
   throw error;
-};
+}
 
 export async function postCandles(
   config: GeckoCollectorConfig,
@@ -1581,9 +1765,7 @@ export async function postCandles(
     sourceRecordedAtIso,
     candles
   };
-  const signal =
-    deps.createTimeoutSignal?.(config.geckoRequestTimeoutMs) ??
-    AbortSignal.timeout(config.geckoRequestTimeoutMs);
+  const signal = AbortSignal.timeout(config.geckoRequestTimeoutMs);
 
   let response: Response;
   try {
@@ -1603,15 +1785,15 @@ export async function postCandles(
   if (!response.ok) {
     throw new HttpError({
       statusCode: response.status,
-      responseBody: await response.text().catch(() => undefined),
       retryable: isRetryableHttpStatus(response.status)
     });
   }
 
   let body: unknown;
   try {
-    body = await response.json();
+    body = JSON.parse(await readTextWithLimit(response));
   } catch (error) {
+    if (error instanceof ProtocolError) throw error;
     throw new ProtocolError(
       `/v1/candles returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`
     );
@@ -1684,6 +1866,7 @@ describe("isMainModule", () => {
 
 describe("runOneCycle", () => {
   it("fetches, normalizes, and posts using one sourceRecordedAtIso", async () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
     const postCandles = vi.fn(async () => ({
       schemaVersion: "1.0" as const,
       insertedCount: 1,
@@ -1695,7 +1878,7 @@ describe("runOneCycle", () => {
     await runOneCycle(config, {
       fetchGeckoOhlcv: vi.fn(async () => payload),
       postCandles,
-      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      logger,
       nowIso: () => "2026-05-01T00:00:00.000Z",
       shouldContinue: () => true
     });
@@ -1706,6 +1889,9 @@ describe("runOneCycle", () => {
       "2026-05-01T00:00:00.000Z",
       expect.any(Object)
     );
+    expect(logger.info).toHaveBeenCalledWith("gecko_fetch_succeeded", expect.any(Object));
+    expect(logger.info).toHaveBeenCalledWith("gecko_ingest_succeeded", expect.any(Object));
+    expect(logger.info).toHaveBeenCalledWith("gecko_cycle_completed", expect.any(Object));
   });
 
   it("skips ingest when shutdown is requested after fetch", async () => {
@@ -1725,7 +1911,7 @@ describe("runOneCycle", () => {
     expect(postCandles).not.toHaveBeenCalled();
   });
 
-  it("logs and skips ingest when corruption guard blocks", async () => {
+  it("logs and skips ingest when zero valid candles block posting", async () => {
     const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
     const rows = Array.from({ length: 20 }, (_, index) => [1 + index, 100, 110, 90, 105, 1]);
     await runOneCycle(config, {
@@ -1738,7 +1924,52 @@ describe("runOneCycle", () => {
 
     expect(logger.warn).toHaveBeenCalledWith(
       "gecko_corruption_guard_blocked",
-      expect.objectContaining({ validCount: 0 })
+      expect.objectContaining({ validCount: 0, guardReason: "zero_valid" })
+    );
+  });
+
+  it("completes in-flight ingest when shutdown is requested during ingest", async () => {
+    let ingestStarted = false;
+    const postCandles = vi.fn(async () => {
+      ingestStarted = true;
+      return {
+        schemaVersion: "1.0" as const,
+        insertedCount: 1,
+        revisedCount: 0,
+        idempotentCount: 0,
+        rejectedCount: 0,
+        rejections: []
+      };
+    });
+
+    await runOneCycle(config, {
+      fetchGeckoOhlcv: vi.fn(async () => payload),
+      postCandles,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      nowIso: () => "2026-05-01T00:00:00.000Z",
+      shouldContinue: () => !ingestStarted
+    });
+
+    expect(postCandles).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs ingest failures before rethrowing", async () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    await expect(
+      runOneCycle(config, {
+        fetchGeckoOhlcv: vi.fn(async () => payload),
+        postCandles: vi.fn(async () => {
+          throw new Error("ingest failed");
+        }),
+        logger,
+        nowIso: () => "2026-05-01T00:00:00.000Z",
+        shouldContinue: () => true
+      })
+    ).rejects.toThrow("ingest failed");
+
+    expect(logger.error).toHaveBeenCalledWith(
+      "gecko_ingest_failed",
+      expect.objectContaining({ errorName: "Error" })
     );
   });
 });
@@ -1759,14 +1990,15 @@ Expected: FAIL because `src/workers/geckoCollector.ts` does not exist.
 Create `src/workers/geckoCollector.ts`:
 
 ```ts
-import { pathToFileURL } from "node:url";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { setTimeout as sleep } from "node:timers/promises";
 import { parseGeckoCollectorConfig, type GeckoCollectorConfig } from "./gecko/config.js";
 import { fetchGeckoOhlcv } from "./gecko/geckoClient.js";
 import { postCandles } from "./gecko/ingestClient.js";
 import { consoleLogger, type WorkerLogger } from "./gecko/logger.js";
-import { normalizeGeckoOhlcv, shouldPostNormalizedBatch } from "./gecko/normalize.js";
-import { createRateLimiter, withRetry } from "./gecko/retry.js";
+import { normalizeGeckoOhlcv } from "./gecko/normalize.js";
+import { createRateLimiter, HttpError, withRetry } from "./gecko/retry.js";
 
 export type GeckoCollectorDeps = {
   fetchGeckoOhlcv?: typeof fetchGeckoOhlcv;
@@ -1774,24 +2006,60 @@ export type GeckoCollectorDeps = {
   logger?: WorkerLogger;
   nowIso?: () => string;
   jitterMs?: (attempt: number) => number;
+  retrySignal?: AbortSignal;
   shouldContinue?: () => boolean;
   waitForProviderPermit?: () => Promise<void>;
 };
 
 const defaultJitterMs = () => Math.floor(Math.random() * 250);
 
-const retryOptions = (shouldContinue: () => boolean, jitterMs: (attempt: number) => number) => ({
+const retryOptions = (
+  shouldContinue: () => boolean,
+  jitterMs: (attempt: number) => number,
+  signal?: AbortSignal
+) => ({
   maxAttempts: 3,
   initialBackoffMs: 1000,
   maxBackoffMs: 30_000,
   jitterMs,
-  sleep: (ms: number) => sleep(ms),
+  sleep: (ms: number, options?: { signal?: AbortSignal }) => sleep(ms, undefined, options),
+  signal,
   shouldContinue
 });
 
 export function isMainModule(importMetaUrl: string, argvPath: string | undefined): boolean {
-  return Boolean(argvPath && importMetaUrl === pathToFileURL(argvPath).href);
+  if (!argvPath) return false;
+  try {
+    return realpathSync(fileURLToPath(importMetaUrl)) === realpathSync(argvPath);
+  } catch {
+    return false;
+  }
 }
+
+const errorContext = (error: unknown): Record<string, string | number | boolean> => {
+  const context: Record<string, string | number | boolean> = {
+    errorName: error instanceof Error ? error.name : "UnknownError"
+  };
+
+  if (error instanceof HttpError) {
+    context.statusCode = error.statusCode;
+    context.retryable = error.retryable;
+  }
+
+  return context;
+};
+
+const guardReason = (
+  stats: ReturnType<typeof normalizeGeckoOhlcv>["stats"],
+  config: GeckoCollectorConfig
+): "zero_valid" | "corruption_rate" | "low_valid_count" | null => {
+  if (stats.validCount === 0) return "zero_valid";
+  if (stats.providerRowCount > 0 && stats.corruptionDroppedCount / stats.providerRowCount > 0.1) {
+    return "corruption_rate";
+  }
+  if (config.geckoLookback >= 50 && stats.validCount < 50) return "low_valid_count";
+  return null;
+};
 
 export async function runOneCycle(
   config: GeckoCollectorConfig,
@@ -1811,32 +2079,58 @@ export async function runOneCycle(
     timeframe: config.geckoTimeframe
   });
 
-  const payload = await withRetry(
-    () =>
-      fetchClient(config, {
-        waitForProviderPermit: deps.waitForProviderPermit ?? (async () => {})
-      }),
-    retryOptions(shouldContinue, jitterMs)
-  );
+  let payload: Awaited<ReturnType<typeof fetchGeckoOhlcv>>;
+  try {
+    payload = await withRetry(
+      () =>
+        fetchClient(config, {
+          waitForProviderPermit: deps.waitForProviderPermit ?? (async () => {})
+        }),
+      retryOptions(shouldContinue, jitterMs, deps.retrySignal)
+    );
+    logger.info("gecko_fetch_succeeded", {
+      provider: config.geckoSource,
+      network: config.geckoNetwork,
+      poolAddress: config.geckoPoolAddress,
+      symbol: config.geckoSymbol,
+      timeframe: config.geckoTimeframe
+    });
+  } catch (error) {
+    logger.error("gecko_fetch_failed", errorContext(error));
+    throw error;
+  }
 
   if (!shouldContinue()) return;
 
   const sourceRecordedAtIso = deps.nowIso?.() ?? new Date().toISOString();
   const normalized = normalizeGeckoOhlcv(payload, config);
+  if (normalized.stats.totalDroppedCount > 0) {
+    logger.warn("gecko_normalization_warn", normalized.stats);
+  }
 
   if (!shouldContinue()) return;
 
-  if (!shouldPostNormalizedBatch(normalized.stats, config)) {
-    logger.warn("gecko_corruption_guard_blocked", normalized.stats);
+  const blockedReason = guardReason(normalized.stats, config);
+  if (blockedReason) {
+    logger.warn("gecko_corruption_guard_blocked", {
+      ...normalized.stats,
+      guardReason: blockedReason
+    });
     return;
   }
 
-  const response = await withRetry(
-    () => ingestClient(config, normalized.validCandles, sourceRecordedAtIso),
-    retryOptions(shouldContinue, jitterMs)
-  );
+  let response: Awaited<ReturnType<typeof postCandles>>;
+  try {
+    response = await withRetry(
+      () => ingestClient(config, normalized.validCandles, sourceRecordedAtIso),
+      retryOptions(shouldContinue, jitterMs, deps.retrySignal)
+    );
+  } catch (error) {
+    logger.error("gecko_ingest_failed", errorContext(error));
+    throw error;
+  }
 
-  logger.info("gecko_ingest_succeeded", {
+  const ingestContext = {
     insertedCount: response.insertedCount,
     revisedCount: response.revisedCount,
     idempotentCount: response.idempotentCount,
@@ -1844,14 +2138,15 @@ export async function runOneCycle(
     candleCountFetched: normalized.stats.providerRowCount,
     candleCountPosted: normalized.validCandles.length,
     sourceRecordedAtIso
-  });
+  };
 
   if (response.rejectedCount > 0) {
-    logger.warn("gecko_ingest_stale_revisions", {
-      rejectedCount: response.rejectedCount,
-      sourceRecordedAtIso
-    });
+    logger.warn("gecko_ingest_succeeded", ingestContext);
+  } else {
+    logger.info("gecko_ingest_succeeded", ingestContext);
   }
+
+  logger.info("gecko_cycle_completed", ingestContext);
 }
 
 export async function runCollector(config = parseGeckoCollectorConfig()): Promise<void> {
@@ -1882,12 +2177,12 @@ export async function runCollector(config = parseGeckoCollectorConfig()): Promis
       await runOneCycle(config, {
         logger,
         waitForProviderPermit,
+        jitterMs: defaultJitterMs,
+        retrySignal: shutdown.signal,
         shouldContinue: () => !shutdownRequested
       });
     } catch (error) {
-      logger.error("gecko_cycle_failed", {
-        errorMessage: error instanceof Error ? error.message : String(error)
-      });
+      logger.error("gecko_cycle_failed", errorContext(error));
     }
 
     if (shutdownRequested) break;
@@ -1907,7 +2202,7 @@ if (isMainModule(import.meta.url, process.argv[1])) {
       JSON.stringify({
         level: "error",
         event: "gecko_collector_fatal",
-        errorMessage: error instanceof Error ? error.message : String(error)
+        ...errorContext(error)
       })
     );
     process.exit(1);
@@ -1969,11 +2264,9 @@ describe("package scripts", () => {
       scripts: Record<string, string>;
     };
 
-    expect(packageJson.scripts.start).toBe("node --env-file-if-exists=.env dist/src/server.js");
-    expect(packageJson.scripts["dev:gecko"]).toBe("tsx watch src/workers/geckoCollector.ts");
-    expect(packageJson.scripts["start:gecko"]).toBe(
-      "node --env-file-if-exists=.env dist/src/workers/geckoCollector.js"
-    );
+    expect(packageJson.scripts.start).toContain("dist/src/server.js");
+    expect(packageJson.scripts["dev:gecko"]).toContain("src/workers/geckoCollector.ts");
+    expect(packageJson.scripts["start:gecko"]).toContain("dist/src/workers/geckoCollector.js");
   });
 });
 ```
@@ -2043,19 +2336,19 @@ npm run start:gecko
 
 Worker env vars:
 
-| Variable                     | Default         | Notes                                                                    |
-| ---------------------------- | --------------- | ------------------------------------------------------------------------ |
-| `REGIME_ENGINE_URL`          | -               | Absolute URL for the regime-engine web service.                          |
-| `CANDLES_INGEST_TOKEN`       | -               | Shared secret sent as `X-Candles-Ingest-Token`.                          |
-| `GECKO_SOURCE`               | `geckoterminal` | Must equal `geckoterminal` for MVP.                                      |
-| `GECKO_NETWORK`              | `solana`        | Must equal `solana` for MVP.                                             |
-| `GECKO_POOL_ADDRESS`         | -               | Explicit GeckoTerminal SOL/USDC pool address. Confirm before production. |
-| `GECKO_SYMBOL`               | `SOL/USDC`      | Must equal `SOL/USDC` for MVP.                                           |
-| `GECKO_TIMEFRAME`            | `1h`            | Must equal `1h` for MVP.                                                 |
-| `GECKO_LOOKBACK`             | `200`           | Rolling candle window size.                                              |
-| `GECKO_POLL_INTERVAL_MS`     | `300000`        | Sleep after each completed cycle.                                        |
-| `GECKO_MAX_CALLS_PER_MINUTE` | `6`             | Provider-scoped GeckoTerminal call cap.                                  |
-| `GECKO_REQUEST_TIMEOUT_MS`   | `10000`         | Per-request timeout for provider and ingest calls.                       |
+| Variable                     | Default         | Notes                                                                     |
+| ---------------------------- | --------------- | ------------------------------------------------------------------------- |
+| `REGIME_ENGINE_URL`          | -               | Absolute URL for the regime-engine web service.                           |
+| `CANDLES_INGEST_TOKEN`       | -               | Shared secret sent as `X-Candles-Ingest-Token`; never commit real values. |
+| `GECKO_SOURCE`               | `geckoterminal` | Must equal `geckoterminal` for MVP.                                       |
+| `GECKO_NETWORK`              | `solana`        | Must equal `solana` for MVP.                                              |
+| `GECKO_POOL_ADDRESS`         | -               | Explicit GeckoTerminal SOL/USDC pool address. Confirm before production.  |
+| `GECKO_SYMBOL`               | `SOL/USDC`      | Must equal `SOL/USDC` for MVP.                                            |
+| `GECKO_TIMEFRAME`            | `1h`            | Must equal `1h` for MVP.                                                  |
+| `GECKO_LOOKBACK`             | `200`           | Rolling candle window size.                                               |
+| `GECKO_POLL_INTERVAL_MS`     | `300000`        | Sleep after each completed cycle.                                         |
+| `GECKO_MAX_CALLS_PER_MINUTE` | `6`             | Provider-scoped GeckoTerminal call cap.                                   |
+| `GECKO_REQUEST_TIMEOUT_MS`   | `10000`         | Per-request timeout for provider and ingest calls.                        |
 
 Railway services from the same repo:
 
@@ -2064,17 +2357,15 @@ Railway services from the same repo:
 | `regime-engine-web`             | `pnpm build` | `pnpm start`       |
 | `regime-engine-gecko-collector` | `pnpm build` | `pnpm start:gecko` |
 
-Production checklist:
-
-- [ ] Confirm the canonical GeckoTerminal Solana SOL/USDC pool address before
-      setting `GECKO_POOL_ADDRESS`.
+Production setup and pool confirmation live in
+`docs/runbooks/railway-deploy.md`.
 ````
 
 - [ ] **Step 6: Update Railway runbook**
 
 Add a section after the web service deployment env vars:
 
-```md
+````md
 ## GeckoTerminal collector Railway service
 
 Create a second service from the same repo:
@@ -2104,12 +2395,36 @@ Collector env vars:
 | `GECKO_MAX_CALLS_PER_MINUTE` | `6`                                                   |
 | `GECKO_REQUEST_TIMEOUT_MS`   | `10000`                                               |
 
+URL notes:
+
+- Public `REGIME_ENGINE_URL` values must use HTTPS.
+- Plain HTTP is accepted only for `localhost`, `127.0.0.1`, `::1`, or Railway
+  private `*.railway.internal` hosts.
+- The collector posts to `new URL("/v1/candles", REGIME_ENGINE_URL)`, which
+  targets the origin root. Do not configure a base URL that relies on a path
+  prefix.
+
+Pool preflight:
+
+```bash
+curl -fsS "https://api.geckoterminal.com/api/v2/networks/solana/pools/$GECKO_POOL_ADDRESS/ohlcv/hour?aggregate=1&limit=1"
+```
+
 Before production:
 
 - [ ] Confirm and record the canonical GeckoTerminal Solana SOL/USDC pool address.
 - [ ] Confirm the collector can reach `REGIME_ENGINE_URL`.
 - [ ] Confirm the web service and collector share the same `CANDLES_INGEST_TOKEN`.
-```
+
+Token management:
+
+1. Generate a new `CANDLES_INGEST_TOKEN` in the password manager.
+2. Update the web service token and collector service token in the same Railway
+   maintenance window.
+3. Restart the web service, then restart the collector service.
+4. Confirm collector logs show successful ingest after rotation.
+5. Treat suspected token exposure as a same-day rotation event.
+````
 
 - [ ] **Step 7: Run package/docs checks**
 

--- a/docs/superpowers/plans/2026-05-01-gecko-terminal-collector.md
+++ b/docs/superpowers/plans/2026-05-01-gecko-terminal-collector.md
@@ -26,6 +26,7 @@ Create:
 - `src/workers/gecko/retry.ts` - `HttpError`, `ProtocolError`, `RequestTimeoutError`, `RequestTransportError`, bounded retry, provider-scoped rate limiter.
 - `src/workers/gecko/logger.ts` - tiny structured console logger and redaction helpers.
 - `src/workers/gecko/__tests__/config.test.ts`
+- `src/workers/gecko/__tests__/logger.test.ts`
 - `src/workers/gecko/__tests__/retry.test.ts`
 - `src/workers/gecko/__tests__/normalize.test.ts`
 - `src/workers/gecko/__tests__/geckoClient.test.ts`
@@ -53,6 +54,7 @@ Do not modify:
 - Create: `src/workers/gecko/config.ts`
 - Create: `src/workers/gecko/logger.ts`
 - Test: `src/workers/gecko/__tests__/config.test.ts`
+- Test: `src/workers/gecko/__tests__/logger.test.ts`
 
 - [ ] **Step 1: Write failing config tests**
 
@@ -112,6 +114,15 @@ describe("parseGeckoCollectorConfig", () => {
     expect(() => parseGeckoCollectorConfig({ ...validEnv, [key]: value })).toThrow(key);
   });
 
+  it.each(["<confirm-before-production>", "<pool>", "pool>", "pool<"])(
+    "rejects placeholder pool address %s",
+    (poolAddress) => {
+      expect(() =>
+        parseGeckoCollectorConfig({ ...validEnv, GECKO_POOL_ADDRESS: poolAddress })
+      ).toThrow("GECKO_POOL_ADDRESS");
+    }
+  );
+
   it("rejects non-absolute REGIME_ENGINE_URL", () => {
     expect(() =>
       parseGeckoCollectorConfig({ ...validEnv, REGIME_ENGINE_URL: "regime-engine.local" })
@@ -155,10 +166,11 @@ describe("parseGeckoCollectorConfig", () => {
     ["GECKO_LOOKBACK", "0"],
     ["GECKO_LOOKBACK", "-1"],
     ["GECKO_LOOKBACK", "1.5"],
+    ["GECKO_LOOKBACK", "1001"],
     ["GECKO_POLL_INTERVAL_MS", "0"],
     ["GECKO_MAX_CALLS_PER_MINUTE", "abc"],
     ["GECKO_REQUEST_TIMEOUT_MS", "-100"]
-  ])("rejects invalid positive integer %s=%s", (key, value) => {
+  ])("rejects invalid numeric env %s=%s", (key, value) => {
     expect(() => parseGeckoCollectorConfig({ ...validEnv, [key]: value })).toThrow(key);
   });
 });
@@ -234,6 +246,22 @@ const readPositiveInteger = (env: NodeJS.ProcessEnv, key: string, defaultValue: 
   return parsed;
 };
 
+const readLookback = (env: NodeJS.ProcessEnv): number => {
+  const value = readPositiveInteger(env, "GECKO_LOOKBACK", 200);
+  if (value > 1000) {
+    throw new Error("GECKO_LOOKBACK must be <= 1000");
+  }
+  return value;
+};
+
+const readPoolAddress = (env: NodeJS.ProcessEnv): string => {
+  const value = readRequired(env, "GECKO_POOL_ADDRESS");
+  if (value.includes("<") || value.includes(">")) {
+    throw new Error("GECKO_POOL_ADDRESS must be a confirmed pool address");
+  }
+  return value;
+};
+
 const isAllowedHttpHost = (hostname: string): boolean => {
   return (
     hostname === "localhost" ||
@@ -273,10 +301,10 @@ export function parseGeckoCollectorConfig(
     candlesIngestToken: readRequired(env, "CANDLES_INGEST_TOKEN"),
     geckoSource: readLiteral(env, "GECKO_SOURCE", "geckoterminal", "geckoterminal"),
     geckoNetwork: readLiteral(env, "GECKO_NETWORK", "solana", "solana"),
-    geckoPoolAddress: readRequired(env, "GECKO_POOL_ADDRESS"),
+    geckoPoolAddress: readPoolAddress(env),
     geckoSymbol: readLiteral(env, "GECKO_SYMBOL", "SOL/USDC", "SOL/USDC"),
     geckoTimeframe: readLiteral(env, "GECKO_TIMEFRAME", "1h", "1h"),
-    geckoLookback: readPositiveInteger(env, "GECKO_LOOKBACK", 200),
+    geckoLookback: readLookback(env),
     geckoPollIntervalMs: readPositiveInteger(env, "GECKO_POLL_INTERVAL_MS", 300_000),
     geckoMaxCallsPerMinute: readPositiveInteger(env, "GECKO_MAX_CALLS_PER_MINUTE", 6),
     geckoRequestTimeoutMs: readPositiveInteger(env, "GECKO_REQUEST_TIMEOUT_MS", 10_000)
@@ -284,7 +312,52 @@ export function parseGeckoCollectorConfig(
 }
 ```
 
-- [ ] **Step 4: Implement minimal redacting logger**
+- [ ] **Step 4: Write logger redaction tests and implement minimal redacting logger**
+
+Create `src/workers/gecko/__tests__/logger.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { redactLogContext } from "../logger.js";
+
+describe("redactLogContext", () => {
+  it("redacts top-level token, header, and response body fields", () => {
+    expect(
+      redactLogContext({
+        CANDLES_INGEST_TOKEN: "secret-token",
+        headers: { "X-Candles-Ingest-Token": "secret-token" },
+        responseBody: "reflected secret-token",
+        poolAddress: "pool"
+      })
+    ).toEqual({
+      CANDLES_INGEST_TOKEN: "[REDACTED]",
+      headers: "[REDACTED]",
+      responseBody: "[REDACTED]",
+      poolAddress: "pool"
+    });
+  });
+
+  it("redacts nested token, header, and response body fields", () => {
+    expect(
+      redactLogContext({
+        error: {
+          requestHeaders: { Authorization: "Bearer secret-token" },
+          nestedToken: "secret-token",
+          responseBody: "reflected secret-token",
+          statusCode: 500
+        }
+      })
+    ).toEqual({
+      error: {
+        requestHeaders: "[REDACTED]",
+        nestedToken: "[REDACTED]",
+        responseBody: "[REDACTED]",
+        statusCode: 500
+      }
+    });
+  });
+});
+```
 
 Create `src/workers/gecko/logger.ts`:
 
@@ -348,12 +421,13 @@ export const consoleLogger: WorkerLogger = {
 };
 ```
 
-- [ ] **Step 5: Run config tests**
+- [ ] **Step 5: Run config and logger tests**
 
 Run:
 
 ```bash
 pnpm exec vitest run src/workers/gecko/__tests__/config.test.ts
+pnpm exec vitest run src/workers/gecko/__tests__/logger.test.ts
 ```
 
 Expected: PASS.
@@ -363,7 +437,7 @@ Expected: PASS.
 Run:
 
 ```bash
-git add src/workers/gecko/config.ts src/workers/gecko/logger.ts src/workers/gecko/__tests__/config.test.ts
+git add src/workers/gecko/config.ts src/workers/gecko/logger.ts src/workers/gecko/__tests__/config.test.ts src/workers/gecko/__tests__/logger.test.ts
 git commit -m "feat: add Gecko collector config"
 ```
 
@@ -851,6 +925,19 @@ describe("normalizeGeckoOhlcv", () => {
     expect(result.stats.malformedRowCount).toBe(1);
   });
 
+  it("drops negative timestamp rows as malformed", () => {
+    const result = normalizeGeckoOhlcv(
+      payload([
+        [-3600, 100, 110, 90, 105, 1],
+        [3600, 100, 110, 90, 105, 1]
+      ]),
+      config
+    );
+
+    expect(result.validCandles.map((candle) => candle.unixMs)).toEqual([3_600_000]);
+    expect(result.stats.malformedRowCount).toBe(1);
+  });
+
   it("dedupes identical rows without adding to corruption dropped count", () => {
     const result = normalizeGeckoOhlcv(
       payload([
@@ -1097,7 +1184,8 @@ const parseRow = (row: unknown, stats: NormalizationStats, timeframeMs: number):
     close === null ||
     volume === null ||
     !Number.isInteger(timestampSeconds) ||
-    !Number.isSafeInteger(timestampSeconds)
+    !Number.isSafeInteger(timestampSeconds) ||
+    timestampSeconds < 0
   ) {
     stats.malformedRowCount += 1;
     increment(stats, "malformed");
@@ -1105,7 +1193,7 @@ const parseRow = (row: unknown, stats: NormalizationStats, timeframeMs: number):
   }
 
   const unixMs = timestampSeconds * 1000;
-  if (!Number.isSafeInteger(unixMs)) {
+  if (!Number.isSafeInteger(unixMs) || unixMs < 0) {
     stats.malformedRowCount += 1;
     increment(stats, "malformed");
     return null;
@@ -1508,7 +1596,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { Candle } from "../../../contract/v1/types.js";
 import type { GeckoCollectorConfig } from "../config.js";
 import { postCandles } from "../ingestClient.js";
-import { HttpError, ProtocolError } from "../retry.js";
+import { HttpError, ProtocolError, RequestTimeoutError, RequestTransportError } from "../retry.js";
 
 const config: GeckoCollectorConfig = {
   regimeEngineUrl: new URL("https://regime-engine.example/base"),
@@ -1654,6 +1742,33 @@ describe("postCandles", () => {
         fetch: fetchMock
       })
     ).rejects.toBeInstanceOf(ProtocolError);
+  });
+
+  it.each(["AbortError", "TimeoutError"])(
+    "wraps %s fetch failures as RequestTimeoutError",
+    async (errorName) => {
+      const fetchMock = vi.fn(async () => {
+        throw new DOMException("aborted", errorName);
+      });
+
+      await expect(
+        postCandles(config, candles, "2026-05-01T00:00:00.000Z", {
+          fetch: fetchMock
+        })
+      ).rejects.toBeInstanceOf(RequestTimeoutError);
+    }
+  );
+
+  it("wraps transport failures as RequestTransportError", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    });
+
+    await expect(
+      postCandles(config, candles, "2026-05-01T00:00:00.000Z", {
+        fetch: fetchMock
+      })
+    ).rejects.toBeInstanceOf(RequestTransportError);
   });
 });
 ```
@@ -1836,6 +1951,10 @@ git commit -m "feat: post Gecko candles to regime engine"
 Create `src/workers/__tests__/geckoCollector.test.ts`:
 
 ```ts
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import type { GeckoCollectorConfig } from "../gecko/config.js";
 import { isMainModule, runOneCycle } from "../geckoCollector.js";
@@ -1861,6 +1980,14 @@ describe("isMainModule", () => {
     expect(isMainModule("file:///repo/src/workers/geckoCollector.ts", "/repo/src/other.ts")).toBe(
       false
     );
+  });
+
+  it("returns true when import URL and argv path resolve to the same real file", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "gecko-collector-"));
+    const entrypoint = join(tempDir, "geckoCollector.ts");
+    writeFileSync(entrypoint, "");
+
+    expect(isMainModule(pathToFileURL(entrypoint).href, entrypoint)).toBe(true);
   });
 });
 
@@ -1896,16 +2023,12 @@ describe("runOneCycle", () => {
 
   it("skips ingest when shutdown is requested after fetch", async () => {
     const postCandles = vi.fn();
-    let calls = 0;
     await runOneCycle(config, {
       fetchGeckoOhlcv: vi.fn(async () => payload),
       postCandles,
       logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
       nowIso: () => "2026-05-01T00:00:00.000Z",
-      shouldContinue: () => {
-        calls += 1;
-        return calls === 1;
-      }
+      shouldContinue: () => false
     });
 
     expect(postCandles).not.toHaveBeenCalled();
@@ -2122,7 +2245,7 @@ export async function runOneCycle(
   let response: Awaited<ReturnType<typeof postCandles>>;
   try {
     response = await withRetry(
-      () => ingestClient(config, normalized.validCandles, sourceRecordedAtIso),
+      () => ingestClient(config, normalized.validCandles, sourceRecordedAtIso, {}),
       retryOptions(shouldContinue, jitterMs, deps.retrySignal)
     );
   } catch (error) {
@@ -2256,8 +2379,6 @@ git commit -m "feat: add Gecko collector loop"
 Append this test to `src/workers/__tests__/geckoCollector.test.ts`:
 
 ```ts
-import { readFileSync } from "node:fs";
-
 describe("package scripts", () => {
   it("points start scripts at dist/src outputs", () => {
     const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {

--- a/docs/superpowers/plans/2026-05-01-gecko-terminal-collector.md
+++ b/docs/superpowers/plans/2026-05-01-gecko-terminal-collector.md
@@ -1,0 +1,2241 @@
+# GeckoTerminal Candle Collector Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a separate zero-dependency GeckoTerminal worker that fetches SOL/USDC 1h OHLCV candles and posts validated rolling-window batches to `POST /v1/candles`.
+
+**Architecture:** Add a small worker slice under `src/workers/` with an ESM-guarded entrypoint, strict env parser, local retry/rate-limit helpers, Gecko fetch client, normalizer, ingest client, and minimal structured logging. The worker runs as a second Railway service and communicates with `regime-engine` only over HTTP.
+
+**Tech Stack:** TypeScript, Node 22 built-in `fetch`, `AbortController`, `node:timers/promises`, Vitest, existing contract types from `src/contract/v1/types.ts`.
+
+---
+
+## Source Spec
+
+Implement from [docs/superpowers/specs/2026-05-01-gecko-terminal-collector-design.md](../specs/2026-05-01-gecko-terminal-collector-design.md).
+
+## File Structure
+
+Create:
+
+- `src/workers/geckoCollector.ts` - ESM-guarded worker entrypoint, immediate-start sequential loop, shutdown phase control.
+- `src/workers/gecko/config.ts` - env parsing, defaults, strict MVP validation.
+- `src/workers/gecko/geckoClient.ts` - GeckoTerminal URL construction, provider fetch, HTTP/protocol error conversion.
+- `src/workers/gecko/normalize.ts` - provider payload validation, Unix seconds to milliseconds conversion, duplicate handling, corruption guard.
+- `src/workers/gecko/ingestClient.ts` - `POST /v1/candles` payload construction, auth header, strict response validation.
+- `src/workers/gecko/retry.ts` - `HttpError`, `ProtocolError`, `RequestTimeoutError`, `RequestTransportError`, bounded retry, provider-scoped rate limiter.
+- `src/workers/gecko/logger.ts` - tiny structured console logger and redaction helpers.
+- `src/workers/gecko/__tests__/config.test.ts`
+- `src/workers/gecko/__tests__/retry.test.ts`
+- `src/workers/gecko/__tests__/normalize.test.ts`
+- `src/workers/gecko/__tests__/geckoClient.test.ts`
+- `src/workers/gecko/__tests__/ingestClient.test.ts`
+- `src/workers/__tests__/geckoCollector.test.ts`
+
+Modify:
+
+- `package.json` - add `start`, `dev:gecko`, and `start:gecko` scripts.
+- `.env.example` - add worker env vars with placeholder pool address.
+- `README.md` - document local worker usage and two Railway services.
+- `docs/runbooks/railway-deploy.md` - add collector service deployment and verification notes.
+
+Do not modify:
+
+- `railway.toml` - the collector runs by Railway service start-command override.
+- `src/app.ts`, `src/server.ts`, `src/http/routes.ts`, `src/ledger/store.ts`, `src/ledger/candleStore.ts`, `src/ledger/candlesWriter.ts`, `src/ledger/pg/db.ts`.
+
+---
+
+### Task 1: Config Parser And Logger Foundation
+
+**Files:**
+
+- Create: `src/workers/gecko/config.ts`
+- Create: `src/workers/gecko/logger.ts`
+- Test: `src/workers/gecko/__tests__/config.test.ts`
+
+- [ ] **Step 1: Write failing config tests**
+
+Create `src/workers/gecko/__tests__/config.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { parseGeckoCollectorConfig } from "../config.js";
+
+const validEnv = {
+  REGIME_ENGINE_URL: "https://regime-engine.example",
+  CANDLES_INGEST_TOKEN: "secret-token",
+  GECKO_POOL_ADDRESS: "solana-pool-address"
+};
+
+describe("parseGeckoCollectorConfig", () => {
+  it("applies MVP defaults", () => {
+    const config = parseGeckoCollectorConfig(validEnv);
+
+    expect(config.regimeEngineUrl.href).toBe("https://regime-engine.example/");
+    expect(config.candlesIngestToken).toBe("secret-token");
+    expect(config.geckoSource).toBe("geckoterminal");
+    expect(config.geckoNetwork).toBe("solana");
+    expect(config.geckoPoolAddress).toBe("solana-pool-address");
+    expect(config.geckoSymbol).toBe("SOL/USDC");
+    expect(config.geckoTimeframe).toBe("1h");
+    expect(config.geckoLookback).toBe(200);
+    expect(config.geckoPollIntervalMs).toBe(300_000);
+    expect(config.geckoMaxCallsPerMinute).toBe(6);
+    expect(config.geckoRequestTimeoutMs).toBe(10_000);
+  });
+
+  it("accepts explicit valid values", () => {
+    const config = parseGeckoCollectorConfig({
+      ...validEnv,
+      GECKO_SOURCE: "geckoterminal",
+      GECKO_NETWORK: "solana",
+      GECKO_SYMBOL: "SOL/USDC",
+      GECKO_TIMEFRAME: "1h",
+      GECKO_LOOKBACK: "250",
+      GECKO_POLL_INTERVAL_MS: "600000",
+      GECKO_MAX_CALLS_PER_MINUTE: "5",
+      GECKO_REQUEST_TIMEOUT_MS: "12000"
+    });
+
+    expect(config.geckoLookback).toBe(250);
+    expect(config.geckoPollIntervalMs).toBe(600_000);
+    expect(config.geckoMaxCallsPerMinute).toBe(5);
+    expect(config.geckoRequestTimeoutMs).toBe(12_000);
+  });
+
+  it.each([
+    ["REGIME_ENGINE_URL", ""],
+    ["CANDLES_INGEST_TOKEN", ""],
+    ["GECKO_POOL_ADDRESS", ""]
+  ])("rejects missing required env %s", (key, value) => {
+    expect(() => parseGeckoCollectorConfig({ ...validEnv, [key]: value })).toThrow(key);
+  });
+
+  it("rejects non-absolute REGIME_ENGINE_URL", () => {
+    expect(() =>
+      parseGeckoCollectorConfig({ ...validEnv, REGIME_ENGINE_URL: "regime-engine.local" })
+    ).toThrow("REGIME_ENGINE_URL");
+  });
+
+  it.each([
+    ["GECKO_SOURCE", "other"],
+    ["GECKO_NETWORK", "ethereum"],
+    ["GECKO_SYMBOL", "ETH/USDC"],
+    ["GECKO_TIMEFRAME", "5m"]
+  ])("rejects unsupported MVP value %s=%s", (key, value) => {
+    expect(() => parseGeckoCollectorConfig({ ...validEnv, [key]: value })).toThrow(key);
+  });
+
+  it.each([
+    ["GECKO_LOOKBACK", "0"],
+    ["GECKO_LOOKBACK", "-1"],
+    ["GECKO_LOOKBACK", "1.5"],
+    ["GECKO_POLL_INTERVAL_MS", "0"],
+    ["GECKO_MAX_CALLS_PER_MINUTE", "abc"],
+    ["GECKO_REQUEST_TIMEOUT_MS", "-100"]
+  ])("rejects invalid positive integer %s=%s", (key, value) => {
+    expect(() => parseGeckoCollectorConfig({ ...validEnv, [key]: value })).toThrow(key);
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing config tests**
+
+Run:
+
+```bash
+pnpm exec vitest run src/workers/gecko/__tests__/config.test.ts
+```
+
+Expected: FAIL because `src/workers/gecko/config.ts` does not exist.
+
+- [ ] **Step 3: Implement config parser**
+
+Create `src/workers/gecko/config.ts`:
+
+```ts
+export type GeckoCollectorConfig = {
+  regimeEngineUrl: URL;
+  candlesIngestToken: string;
+  geckoSource: "geckoterminal";
+  geckoNetwork: "solana";
+  geckoPoolAddress: string;
+  geckoSymbol: "SOL/USDC";
+  geckoTimeframe: "1h";
+  geckoLookback: number;
+  geckoPollIntervalMs: number;
+  geckoMaxCallsPerMinute: number;
+  geckoRequestTimeoutMs: number;
+};
+
+const readRequired = (env: NodeJS.ProcessEnv, key: string): string => {
+  const value = env[key]?.trim();
+  if (!value) {
+    throw new Error(`${key} is required`);
+  }
+  return value;
+};
+
+const readLiteral = <T extends string>(
+  env: NodeJS.ProcessEnv,
+  key: string,
+  defaultValue: T,
+  allowed: T
+): T => {
+  const value = (env[key]?.trim() || defaultValue) as T;
+  if (value !== allowed) {
+    throw new Error(`${key} must equal ${allowed}`);
+  }
+  return value;
+};
+
+const readPositiveInteger = (env: NodeJS.ProcessEnv, key: string, defaultValue: number): number => {
+  const raw = env[key]?.trim() || String(defaultValue);
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${key} must be a positive integer`);
+  }
+  return parsed;
+};
+
+const readAbsoluteUrl = (env: NodeJS.ProcessEnv, key: string): URL => {
+  const raw = readRequired(env, key);
+  try {
+    const url = new URL(raw);
+    if (!url.protocol || !url.hostname) {
+      throw new Error("missing protocol or host");
+    }
+    return url;
+  } catch {
+    throw new Error(`${key} must be an absolute URL`);
+  }
+};
+
+export function parseGeckoCollectorConfig(
+  env: NodeJS.ProcessEnv = process.env
+): GeckoCollectorConfig {
+  return {
+    regimeEngineUrl: readAbsoluteUrl(env, "REGIME_ENGINE_URL"),
+    candlesIngestToken: readRequired(env, "CANDLES_INGEST_TOKEN"),
+    geckoSource: readLiteral(env, "GECKO_SOURCE", "geckoterminal", "geckoterminal"),
+    geckoNetwork: readLiteral(env, "GECKO_NETWORK", "solana", "solana"),
+    geckoPoolAddress: readRequired(env, "GECKO_POOL_ADDRESS"),
+    geckoSymbol: readLiteral(env, "GECKO_SYMBOL", "SOL/USDC", "SOL/USDC"),
+    geckoTimeframe: readLiteral(env, "GECKO_TIMEFRAME", "1h", "1h"),
+    geckoLookback: readPositiveInteger(env, "GECKO_LOOKBACK", 200),
+    geckoPollIntervalMs: readPositiveInteger(env, "GECKO_POLL_INTERVAL_MS", 300_000),
+    geckoMaxCallsPerMinute: readPositiveInteger(env, "GECKO_MAX_CALLS_PER_MINUTE", 6),
+    geckoRequestTimeoutMs: readPositiveInteger(env, "GECKO_REQUEST_TIMEOUT_MS", 10_000)
+  };
+}
+```
+
+- [ ] **Step 4: Implement minimal redacting logger**
+
+Create `src/workers/gecko/logger.ts`:
+
+```ts
+export type LogContext = Record<string, unknown>;
+
+export type WorkerLogger = {
+  info: (event: string, context?: LogContext) => void;
+  warn: (event: string, context?: LogContext) => void;
+  error: (event: string, context?: LogContext) => void;
+};
+
+const SECRET_KEYS = new Set([
+  "candlesIngestToken",
+  "CANDLES_INGEST_TOKEN",
+  "x-candles-ingest-token"
+]);
+
+export const redactLogContext = (context: LogContext = {}): LogContext => {
+  const redacted: LogContext = {};
+  for (const [key, value] of Object.entries(context)) {
+    if (SECRET_KEYS.has(key) || key.toLowerCase().includes("token")) {
+      redacted[key] = "[REDACTED]";
+    } else if (key.toLowerCase() === "headers") {
+      redacted[key] = "[REDACTED]";
+    } else {
+      redacted[key] = value;
+    }
+  }
+  return redacted;
+};
+
+const write = (level: "info" | "warn" | "error", event: string, context: LogContext = {}) => {
+  const payload = {
+    level,
+    event,
+    at: new Date().toISOString(),
+    ...redactLogContext(context)
+  };
+  const line = JSON.stringify(payload);
+  if (level === "error") {
+    console.error(line);
+  } else if (level === "warn") {
+    console.warn(line);
+  } else {
+    console.log(line);
+  }
+};
+
+export const consoleLogger: WorkerLogger = {
+  info: (event, context) => write("info", event, context),
+  warn: (event, context) => write("warn", event, context),
+  error: (event, context) => write("error", event, context)
+};
+```
+
+- [ ] **Step 5: Run config tests**
+
+Run:
+
+```bash
+pnpm exec vitest run src/workers/gecko/__tests__/config.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit config and logger foundation**
+
+Run:
+
+```bash
+git add src/workers/gecko/config.ts src/workers/gecko/logger.ts src/workers/gecko/__tests__/config.test.ts
+git commit -m "feat: add Gecko collector config"
+```
+
+---
+
+### Task 2: Retry, HTTP Errors, And Provider Rate Limiter
+
+**Files:**
+
+- Create: `src/workers/gecko/retry.ts`
+- Test: `src/workers/gecko/__tests__/retry.test.ts`
+
+- [ ] **Step 1: Write failing retry tests**
+
+Create `src/workers/gecko/__tests__/retry.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import {
+  HttpError,
+  ProtocolError,
+  RequestTransportError,
+  RequestTimeoutError,
+  createRateLimiter,
+  isRetryableHttpStatus,
+  withRetry
+} from "../retry.js";
+
+describe("HttpError", () => {
+  it("stores status, response body, and retryable flag", () => {
+    const error = new HttpError({
+      statusCode: 429,
+      responseBody: "too many",
+      retryable: true,
+      message: "rate limited"
+    });
+
+    expect(error.message).toBe("rate limited");
+    expect(error.statusCode).toBe(429);
+    expect(error.responseBody).toBe("too many");
+    expect(error.retryable).toBe(true);
+  });
+});
+
+describe("isRetryableHttpStatus", () => {
+  it.each([429, 500, 502, 503, 504])("marks %s retryable", (status) => {
+    expect(isRetryableHttpStatus(status)).toBe(true);
+  });
+
+  it.each([400, 401, 403, 404, 409])("marks %s non-retryable", (status) => {
+    expect(isRetryableHttpStatus(status)).toBe(false);
+  });
+});
+
+describe("withRetry", () => {
+  it("retries retryable errors with exponential backoff and jitter", async () => {
+    const sleep = vi.fn(async () => {});
+    const operation = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new RequestTimeoutError("timeout"))
+      .mockRejectedValueOnce(new HttpError({ statusCode: 503, retryable: true }))
+      .mockResolvedValue("ok");
+
+    await expect(
+      withRetry((attempt) => operation().then((value) => `${value}:${attempt}`), {
+        maxAttempts: 3,
+        initialBackoffMs: 1000,
+        maxBackoffMs: 30000,
+        jitterMs: (attempt) => attempt * 10,
+        sleep
+      })
+    ).resolves.toBe("ok:3");
+
+    expect(sleep).toHaveBeenNthCalledWith(1, 1010);
+    expect(sleep).toHaveBeenNthCalledWith(2, 2020);
+  });
+
+  it("does not retry non-retryable HttpError", async () => {
+    const sleep = vi.fn(async () => {});
+    const operation = vi.fn(async () => {
+      throw new HttpError({ statusCode: 404, retryable: false });
+    });
+
+    await expect(
+      withRetry(operation, {
+        maxAttempts: 3,
+        initialBackoffMs: 1000,
+        maxBackoffMs: 30000,
+        jitterMs: () => 0,
+        sleep
+      })
+    ).rejects.toBeInstanceOf(HttpError);
+
+    expect(operation).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("does not retry protocol errors", async () => {
+    const operation = vi.fn(async () => {
+      throw new ProtocolError("bad json");
+    });
+
+    await expect(
+      withRetry(operation, {
+        maxAttempts: 3,
+        initialBackoffMs: 1000,
+        maxBackoffMs: 30000,
+        jitterMs: () => 0,
+        sleep: vi.fn(async () => {})
+      })
+    ).rejects.toBeInstanceOf(ProtocolError);
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry unclassified programmer errors", async () => {
+    const operation = vi.fn(async () => {
+      throw new TypeError("programmer error");
+    });
+
+    await expect(
+      withRetry(operation, {
+        maxAttempts: 3,
+        initialBackoffMs: 1000,
+        maxBackoffMs: 30000,
+        jitterMs: () => 0,
+        sleep: vi.fn(async () => {})
+      })
+    ).rejects.toBeInstanceOf(TypeError);
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries explicitly classified transport errors", async () => {
+    const operation = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new RequestTransportError("fetch failed"))
+      .mockResolvedValue("ok");
+
+    await expect(
+      withRetry(operation, {
+        maxAttempts: 2,
+        initialBackoffMs: 1000,
+        maxBackoffMs: 30000,
+        jitterMs: () => 0,
+        sleep: vi.fn(async () => {})
+      })
+    ).resolves.toBe("ok");
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops before another attempt when shouldContinue returns false", async () => {
+    const operation = vi.fn(async () => {
+      throw new HttpError({ statusCode: 503, retryable: true });
+    });
+
+    await expect(
+      withRetry(operation, {
+        maxAttempts: 3,
+        initialBackoffMs: 1000,
+        maxBackoffMs: 30000,
+        jitterMs: () => 0,
+        sleep: vi.fn(async () => {}),
+        shouldContinue: () => false
+      })
+    ).rejects.toBeInstanceOf(HttpError);
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createRateLimiter", () => {
+  it("allows first call immediately and spaces later calls", async () => {
+    let now = 10_000;
+    const sleep = vi.fn(async (ms: number) => {
+      now += ms;
+    });
+    const waitForPermit = createRateLimiter(6, { sleep, now: () => now });
+
+    await waitForPermit();
+    await waitForPermit();
+    await waitForPermit();
+
+    expect(sleep).toHaveBeenNthCalledWith(1, 10_000);
+    expect(sleep).toHaveBeenNthCalledWith(2, 10_000);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing retry tests**
+
+Run:
+
+```bash
+pnpm exec vitest run src/workers/gecko/__tests__/retry.test.ts
+```
+
+Expected: FAIL because `src/workers/gecko/retry.ts` does not exist.
+
+- [ ] **Step 3: Implement retry helpers**
+
+Create `src/workers/gecko/retry.ts`:
+
+```ts
+import { setTimeout as defaultSleep } from "node:timers/promises";
+
+export type HttpErrorOptions = {
+  statusCode: number;
+  responseBody?: string;
+  retryable?: boolean;
+  message?: string;
+};
+
+export class HttpError extends Error {
+  public readonly statusCode: number;
+  public readonly responseBody?: string;
+  public readonly retryable: boolean;
+
+  public constructor(options: HttpErrorOptions) {
+    super(options.message ?? `HTTP ${options.statusCode}`);
+    this.name = "HttpError";
+    this.statusCode = options.statusCode;
+    this.responseBody = options.responseBody;
+    this.retryable = options.retryable ?? isRetryableHttpStatus(options.statusCode);
+  }
+}
+
+export class ProtocolError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "ProtocolError";
+  }
+}
+
+export class RequestTimeoutError extends Error {
+  public constructor(message = "Request timed out") {
+    super(message);
+    this.name = "RequestTimeoutError";
+  }
+}
+
+export class RequestTransportError extends Error {
+  public constructor(message = "Request transport failed") {
+    super(message);
+    this.name = "RequestTransportError";
+  }
+}
+
+export type RetryOptions = {
+  maxAttempts: number;
+  initialBackoffMs: number;
+  maxBackoffMs: number;
+  jitterMs: (attempt: number) => number;
+  sleep: (ms: number) => Promise<unknown>;
+  shouldContinue?: () => boolean;
+};
+
+export const isRetryableHttpStatus = (status: number): boolean => {
+  return status === 429 || status >= 500;
+};
+
+const isRetryableError = (error: unknown): boolean => {
+  if (error instanceof HttpError) return error.retryable;
+  if (error instanceof RequestTimeoutError) return true;
+  if (error instanceof RequestTransportError) return true;
+  if (error instanceof ProtocolError) return false;
+  return false;
+};
+
+export async function withRetry<T>(
+  operation: (attempt: number) => Promise<T>,
+  options: RetryOptions
+): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= options.maxAttempts; attempt += 1) {
+    try {
+      return await operation(attempt);
+    } catch (error) {
+      lastError = error;
+      if (!isRetryableError(error) || attempt >= options.maxAttempts) {
+        throw error;
+      }
+      if (options.shouldContinue && !options.shouldContinue()) {
+        throw error;
+      }
+
+      const exponential = options.initialBackoffMs * 2 ** (attempt - 1);
+      const capped = Math.min(options.maxBackoffMs, exponential);
+      await options.sleep(capped + options.jitterMs(attempt));
+
+      if (options.shouldContinue && !options.shouldContinue()) {
+        throw error;
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+export function createRateLimiter(
+  maxCallsPerMinute: number,
+  deps: {
+    sleep?: (ms: number) => Promise<unknown>;
+    now?: () => number;
+  } = {}
+): () => Promise<void> {
+  const intervalMs = 60_000 / maxCallsPerMinute;
+  const sleep = deps.sleep ?? ((ms: number) => defaultSleep(ms));
+  const now = deps.now ?? (() => Date.now());
+  let nextAllowedAt = 0;
+
+  return async () => {
+    const current = now();
+    const waitMs = Math.max(0, nextAllowedAt - current);
+    if (waitMs > 0) {
+      await sleep(waitMs);
+    }
+    nextAllowedAt = Math.max(current, nextAllowedAt) + intervalMs;
+  };
+}
+```
+
+- [ ] **Step 4: Run retry tests**
+
+Run:
+
+```bash
+pnpm exec vitest run src/workers/gecko/__tests__/retry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit retry and rate limiter**
+
+Run:
+
+```bash
+git add src/workers/gecko/retry.ts src/workers/gecko/__tests__/retry.test.ts
+git commit -m "feat: add Gecko collector retry helpers"
+```
+
+---
+
+### Task 3: Gecko Normalizer And Corruption Guard
+
+**Files:**
+
+- Create: `src/workers/gecko/normalize.ts`
+- Test: `src/workers/gecko/__tests__/normalize.test.ts`
+
+- [ ] **Step 1: Write failing normalizer tests**
+
+Create `src/workers/gecko/__tests__/normalize.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { GeckoCollectorConfig } from "../config.js";
+import { normalizeGeckoOhlcv, shouldPostNormalizedBatch } from "../normalize.js";
+
+const config: GeckoCollectorConfig = {
+  regimeEngineUrl: new URL("https://regime-engine.example"),
+  candlesIngestToken: "secret",
+  geckoSource: "geckoterminal",
+  geckoNetwork: "solana",
+  geckoPoolAddress: "pool",
+  geckoSymbol: "SOL/USDC",
+  geckoTimeframe: "1h",
+  geckoLookback: 200,
+  geckoPollIntervalMs: 300_000,
+  geckoMaxCallsPerMinute: 6,
+  geckoRequestTimeoutMs: 10_000
+};
+
+const payload = (rows: unknown[]) => ({
+  data: {
+    attributes: {
+      ohlcv_list: rows
+    }
+  }
+});
+
+describe("normalizeGeckoOhlcv", () => {
+  it("converts Gecko Unix seconds into contract Unix milliseconds", () => {
+    const result = normalizeGeckoOhlcv(payload([[3600, 100, 110, 90, 105, 123.45]]), config);
+
+    expect(result.validCandles).toEqual([
+      { unixMs: 3_600_000, open: 100, high: 110, low: 90, close: 105, volume: 123.45 }
+    ]);
+    expect(result.stats.providerRowCount).toBe(1);
+    expect(result.stats.validCount).toBe(1);
+  });
+
+  it("throws ProtocolError for malformed top-level envelope", () => {
+    expect(() => normalizeGeckoOhlcv({ data: { attributes: {} } }, config)).toThrow("ohlcv_list");
+  });
+
+  it("drops non-array rows and rows with missing or extra fields", () => {
+    const result = normalizeGeckoOhlcv(
+      payload([
+        "not-array",
+        [3600, 100, 110, 90, 105],
+        [7200, 100, 110, 90, 105, 1, "extra"],
+        [10_800, 100, 110, 90, 105, 1]
+      ]),
+      config
+    );
+
+    expect(result.validCandles.map((candle) => candle.unixMs)).toEqual([10_800_000]);
+    expect(result.stats.malformedRowCount).toBe(3);
+    expect(result.stats.corruptionDroppedCount).toBe(3);
+  });
+
+  it("drops misaligned and invalid OHLCV rows", () => {
+    const result = normalizeGeckoOhlcv(
+      payload([
+        [1, 100, 110, 90, 105, 1],
+        [3600, 0, 110, 90, 105, 1],
+        [7200, 100, 99, 90, 105, 1],
+        [10_800, 100, 110, 90, 105, -1],
+        [14_400, 100, 110, 90, 105, 1]
+      ]),
+      config
+    );
+
+    expect(result.validCandles.map((candle) => candle.unixMs)).toEqual([14_400_000]);
+    expect(result.stats.misalignedRowCount).toBe(1);
+    expect(result.stats.invalidOhlcvRowCount).toBe(3);
+  });
+
+  it("dedupes identical rows without adding to corruption dropped count", () => {
+    const result = normalizeGeckoOhlcv(
+      payload([
+        [3600, 100, 110, 90, 105, 1],
+        [3600, 100, 110, 90, 105, 1]
+      ]),
+      config
+    );
+
+    expect(result.validCandles).toHaveLength(1);
+    expect(result.stats.duplicateIdenticalDroppedCount).toBe(1);
+    expect(result.stats.totalDroppedCount).toBe(1);
+    expect(result.stats.corruptionDroppedCount).toBe(0);
+  });
+
+  it("drops all rows for conflicting duplicate timestamps", () => {
+    const result = normalizeGeckoOhlcv(
+      payload([
+        [3600, 100, 110, 90, 105, 1],
+        [3600, 101, 111, 91, 106, 1],
+        [7200, 100, 110, 90, 105, 1]
+      ]),
+      config
+    );
+
+    expect(result.validCandles.map((candle) => candle.unixMs)).toEqual([7_200_000]);
+    expect(result.stats.duplicateConflictDroppedCount).toBe(2);
+    expect(result.stats.corruptionDroppedCount).toBe(2);
+  });
+
+  it("sorts valid candles by unixMs ascending", () => {
+    const result = normalizeGeckoOhlcv(
+      payload([
+        [7200, 100, 110, 90, 105, 1],
+        [3600, 100, 110, 90, 105, 1]
+      ]),
+      config
+    );
+
+    expect(result.validCandles.map((candle) => candle.unixMs)).toEqual([3_600_000, 7_200_000]);
+  });
+});
+
+describe("shouldPostNormalizedBatch", () => {
+  it("blocks zero-valid batches", () => {
+    expect(
+      shouldPostNormalizedBatch(
+        {
+          providerRowCount: 0,
+          malformedRowCount: 0,
+          misalignedRowCount: 0,
+          invalidOhlcvRowCount: 0,
+          duplicateIdenticalDroppedCount: 0,
+          duplicateConflictDroppedCount: 0,
+          totalDroppedCount: 0,
+          corruptionDroppedCount: 0,
+          validCount: 0,
+          dropReasons: {}
+        },
+        config
+      )
+    ).toBe(false);
+  });
+
+  it("blocks corruption rate above 10 percent", () => {
+    expect(
+      shouldPostNormalizedBatch(
+        {
+          providerRowCount: 100,
+          malformedRowCount: 11,
+          misalignedRowCount: 0,
+          invalidOhlcvRowCount: 0,
+          duplicateIdenticalDroppedCount: 0,
+          duplicateConflictDroppedCount: 0,
+          totalDroppedCount: 11,
+          corruptionDroppedCount: 11,
+          validCount: 89,
+          dropReasons: { malformed: 11 }
+        },
+        config
+      )
+    ).toBe(false);
+  });
+
+  it("does not block exact duplicates by corruption rate", () => {
+    expect(
+      shouldPostNormalizedBatch(
+        {
+          providerRowCount: 100,
+          malformedRowCount: 0,
+          misalignedRowCount: 0,
+          invalidOhlcvRowCount: 0,
+          duplicateIdenticalDroppedCount: 90,
+          duplicateConflictDroppedCount: 0,
+          totalDroppedCount: 90,
+          corruptionDroppedCount: 0,
+          validCount: 10,
+          dropReasons: { duplicate_identical: 90 }
+        },
+        { ...config, geckoLookback: 10 }
+      )
+    ).toBe(true);
+  });
+
+  it("blocks low valid count when lookback is at least 50", () => {
+    expect(
+      shouldPostNormalizedBatch(
+        {
+          providerRowCount: 49,
+          malformedRowCount: 0,
+          misalignedRowCount: 0,
+          invalidOhlcvRowCount: 0,
+          duplicateIdenticalDroppedCount: 0,
+          duplicateConflictDroppedCount: 0,
+          totalDroppedCount: 0,
+          corruptionDroppedCount: 0,
+          validCount: 49,
+          dropReasons: {}
+        },
+        config
+      )
+    ).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing normalizer tests**
+
+Run:
+
+```bash
+pnpm exec vitest run src/workers/gecko/__tests__/normalize.test.ts
+```
+
+Expected: FAIL because `src/workers/gecko/normalize.ts` does not exist.
+
+- [ ] **Step 3: Implement normalizer**
+
+Create `src/workers/gecko/normalize.ts` with these exported types and functions:
+
+```ts
+import type { Candle } from "../../contract/v1/types.js";
+import type { GeckoCollectorConfig } from "./config.js";
+import { ProtocolError } from "./retry.js";
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+export type NormalizationStats = {
+  providerRowCount: number;
+  malformedRowCount: number;
+  misalignedRowCount: number;
+  invalidOhlcvRowCount: number;
+  duplicateIdenticalDroppedCount: number;
+  duplicateConflictDroppedCount: number;
+  totalDroppedCount: number;
+  corruptionDroppedCount: number;
+  validCount: number;
+  dropReasons: Record<string, number>;
+};
+
+export type NormalizationResult = {
+  validCandles: Candle[];
+  stats: NormalizationStats;
+};
+
+const increment = (stats: NormalizationStats, reason: string): void => {
+  stats.dropReasons[reason] = (stats.dropReasons[reason] ?? 0) + 1;
+};
+
+const emptyStats = (): NormalizationStats => ({
+  providerRowCount: 0,
+  malformedRowCount: 0,
+  misalignedRowCount: 0,
+  invalidOhlcvRowCount: 0,
+  duplicateIdenticalDroppedCount: 0,
+  duplicateConflictDroppedCount: 0,
+  totalDroppedCount: 0,
+  corruptionDroppedCount: 0,
+  validCount: 0,
+  dropReasons: {}
+});
+
+const readRows = (payload: unknown): unknown[] => {
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    !("data" in payload) ||
+    typeof payload.data !== "object" ||
+    payload.data === null ||
+    !("attributes" in payload.data) ||
+    typeof payload.data.attributes !== "object" ||
+    payload.data.attributes === null ||
+    !("ohlcv_list" in payload.data.attributes) ||
+    !Array.isArray(payload.data.attributes.ohlcv_list)
+  ) {
+    throw new ProtocolError("GeckoTerminal payload missing data.attributes.ohlcv_list array");
+  }
+  return payload.data.attributes.ohlcv_list;
+};
+
+const sameOhlcv = (a: Candle, b: Candle): boolean =>
+  a.unixMs === b.unixMs &&
+  a.open === b.open &&
+  a.high === b.high &&
+  a.low === b.low &&
+  a.close === b.close &&
+  a.volume === b.volume;
+
+const toFiniteNumber = (value: unknown): number | null => {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return value;
+};
+
+const parseRow = (row: unknown, stats: NormalizationStats): Candle | null => {
+  if (!Array.isArray(row) || row.length !== 6) {
+    stats.malformedRowCount += 1;
+    increment(stats, "malformed");
+    return null;
+  }
+
+  const [timestampSecondsRaw, openRaw, highRaw, lowRaw, closeRaw, volumeRaw] = row;
+  const timestampSeconds = toFiniteNumber(timestampSecondsRaw);
+  const open = toFiniteNumber(openRaw);
+  const high = toFiniteNumber(highRaw);
+  const low = toFiniteNumber(lowRaw);
+  const close = toFiniteNumber(closeRaw);
+  const volume = toFiniteNumber(volumeRaw);
+
+  if (
+    timestampSeconds === null ||
+    open === null ||
+    high === null ||
+    low === null ||
+    close === null ||
+    volume === null ||
+    !Number.isInteger(timestampSeconds)
+  ) {
+    stats.malformedRowCount += 1;
+    increment(stats, "malformed");
+    return null;
+  }
+
+  const unixMs = timestampSeconds * 1000;
+  if (!Number.isInteger(unixMs) || unixMs % ONE_HOUR_MS !== 0) {
+    stats.misalignedRowCount += 1;
+    increment(stats, "misaligned");
+    return null;
+  }
+
+  if (
+    open <= 0 ||
+    high <= 0 ||
+    low <= 0 ||
+    close <= 0 ||
+    volume < 0 ||
+    high < Math.max(open, close, low) ||
+    low > Math.min(open, close, high)
+  ) {
+    stats.invalidOhlcvRowCount += 1;
+    increment(stats, "invalid_ohlcv");
+    return null;
+  }
+
+  return { unixMs, open, high, low, close, volume };
+};
+
+export function normalizeGeckoOhlcv(
+  payload: unknown,
+  _config: GeckoCollectorConfig
+): NormalizationResult {
+  const rows = readRows(payload);
+  const stats = emptyStats();
+  stats.providerRowCount = rows.length;
+
+  const groups = new Map<number, Candle[]>();
+  for (const row of rows) {
+    const candle = parseRow(row, stats);
+    if (!candle) continue;
+    const existing = groups.get(candle.unixMs) ?? [];
+    existing.push(candle);
+    groups.set(candle.unixMs, existing);
+  }
+
+  const validCandles: Candle[] = [];
+  for (const candles of groups.values()) {
+    const [first] = candles;
+    if (candles.every((candidate) => sameOhlcv(first, candidate))) {
+      validCandles.push(first);
+      const duplicateCount = candles.length - 1;
+      if (duplicateCount > 0) {
+        stats.duplicateIdenticalDroppedCount += duplicateCount;
+        stats.dropReasons.duplicate_identical =
+          (stats.dropReasons.duplicate_identical ?? 0) + duplicateCount;
+      }
+    } else {
+      stats.duplicateConflictDroppedCount += candles.length;
+      stats.dropReasons.duplicate_conflict =
+        (stats.dropReasons.duplicate_conflict ?? 0) + candles.length;
+    }
+  }
+
+  validCandles.sort((a, b) => a.unixMs - b.unixMs);
+  stats.totalDroppedCount =
+    stats.malformedRowCount +
+    stats.misalignedRowCount +
+    stats.invalidOhlcvRowCount +
+    stats.duplicateIdenticalDroppedCount +
+    stats.duplicateConflictDroppedCount;
+  stats.corruptionDroppedCount =
+    stats.malformedRowCount +
+    stats.misalignedRowCount +
+    stats.invalidOhlcvRowCount +
+    stats.duplicateConflictDroppedCount;
+  stats.validCount = validCandles.length;
+
+  return { validCandles, stats };
+}
+
+export function shouldPostNormalizedBatch(
+  stats: NormalizationStats,
+  config: GeckoCollectorConfig
+): boolean {
+  if (stats.validCount === 0) return false;
+  if (stats.providerRowCount > 0 && stats.corruptionDroppedCount / stats.providerRowCount > 0.1) {
+    return false;
+  }
+  if (config.geckoLookback >= 50 && stats.validCount < 50) {
+    return false;
+  }
+  return true;
+}
+```
+
+- [ ] **Step 4: Run normalizer tests**
+
+Run:
+
+```bash
+pnpm exec vitest run src/workers/gecko/__tests__/normalize.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit normalizer**
+
+Run:
+
+```bash
+git add src/workers/gecko/normalize.ts src/workers/gecko/__tests__/normalize.test.ts
+git commit -m "feat: normalize Gecko OHLCV candles"
+```
+
+---
+
+### Task 4: GeckoTerminal Fetch Client
+
+**Files:**
+
+- Create: `src/workers/gecko/geckoClient.ts`
+- Test: `src/workers/gecko/__tests__/geckoClient.test.ts`
+
+- [ ] **Step 1: Write failing Gecko client tests**
+
+Create `src/workers/gecko/__tests__/geckoClient.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import type { GeckoCollectorConfig } from "../config.js";
+import { fetchGeckoOhlcv } from "../geckoClient.js";
+import { HttpError, ProtocolError, RequestTimeoutError, RequestTransportError } from "../retry.js";
+
+const config: GeckoCollectorConfig = {
+  regimeEngineUrl: new URL("https://regime-engine.example"),
+  candlesIngestToken: "secret",
+  geckoSource: "geckoterminal",
+  geckoNetwork: "solana",
+  geckoPoolAddress: "pool address/with spaces",
+  geckoSymbol: "SOL/USDC",
+  geckoTimeframe: "1h",
+  geckoLookback: 200,
+  geckoPollIntervalMs: 300_000,
+  geckoMaxCallsPerMinute: 6,
+  geckoRequestTimeoutMs: 10_000
+};
+
+const okPayload = { data: { attributes: { ohlcv_list: [] } } };
+
+describe("fetchGeckoOhlcv", () => {
+  it("builds encoded Gecko OHLCV URL and sends JSON accept header", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify(okPayload), { status: 200 }));
+    const waitForProviderPermit = vi.fn(async () => {});
+
+    await fetchGeckoOhlcv(config, {
+      fetch: fetchMock,
+      waitForProviderPermit,
+      createTimeoutSignal: () => undefined
+    });
+
+    expect(waitForProviderPermit).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe(
+      "https://api.geckoterminal.com/api/v2/networks/solana/pools/pool%20address%2Fwith%20spaces/ohlcv/hour?aggregate=1&limit=200"
+    );
+    expect(init?.headers).toEqual({ Accept: "application/json" });
+  });
+
+  it("throws retryable HttpError for 429 and 5xx", async () => {
+    for (const status of [429, 503]) {
+      const fetchMock = vi.fn(async () => new Response("error", { status }));
+
+      await expect(
+        fetchGeckoOhlcv(config, {
+          fetch: fetchMock,
+          waitForProviderPermit: async () => {},
+          createTimeoutSignal: () => undefined
+        })
+      ).rejects.toMatchObject({ statusCode: status, retryable: true });
+    }
+  });
+
+  it("throws non-retryable HttpError for non-429 4xx", async () => {
+    const fetchMock = vi.fn(async () => new Response("missing", { status: 404 }));
+
+    await expect(
+      fetchGeckoOhlcv(config, {
+        fetch: fetchMock,
+        waitForProviderPermit: async () => {},
+        createTimeoutSignal: () => undefined
+      })
+    ).rejects.toMatchObject({ statusCode: 404, retryable: false });
+  });
+
+  it("throws ProtocolError for invalid 2xx JSON", async () => {
+    const fetchMock = vi.fn(async () => new Response("{", { status: 200 }));
+
+    await expect(
+      fetchGeckoOhlcv(config, {
+        fetch: fetchMock,
+        waitForProviderPermit: async () => {},
+        createTimeoutSignal: () => undefined
+      })
+    ).rejects.toBeInstanceOf(ProtocolError);
+  });
+
+  it("wraps timeout aborts as RequestTimeoutError", async () => {
+    const abortError = new DOMException("aborted", "TimeoutError");
+    const fetchMock = vi.fn(async () => {
+      throw abortError;
+    });
+
+    await expect(
+      fetchGeckoOhlcv(config, {
+        fetch: fetchMock,
+        waitForProviderPermit: async () => {},
+        createTimeoutSignal: () => undefined
+      })
+    ).rejects.toBeInstanceOf(RequestTimeoutError);
+  });
+
+  it("wraps transport failures as RequestTransportError", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    });
+
+    await expect(
+      fetchGeckoOhlcv(config, {
+        fetch: fetchMock,
+        waitForProviderPermit: async () => {},
+        createTimeoutSignal: () => undefined
+      })
+    ).rejects.toBeInstanceOf(RequestTransportError);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing Gecko client tests**
+
+Run:
+
+```bash
+pnpm exec vitest run src/workers/gecko/__tests__/geckoClient.test.ts
+```
+
+Expected: FAIL because `src/workers/gecko/geckoClient.ts` does not exist.
+
+- [ ] **Step 3: Implement Gecko client**
+
+Create `src/workers/gecko/geckoClient.ts`:
+
+```ts
+import type { GeckoCollectorConfig } from "./config.js";
+import {
+  HttpError,
+  ProtocolError,
+  RequestTimeoutError,
+  RequestTransportError,
+  isRetryableHttpStatus
+} from "./retry.js";
+
+export type GeckoOhlcvPayload = unknown;
+
+export type GeckoFetchDeps = {
+  fetch?: typeof fetch;
+  waitForProviderPermit: () => Promise<void>;
+  createTimeoutSignal?: (timeoutMs: number) => AbortSignal | undefined;
+};
+
+const encodeSegment = (segment: string): string => encodeURIComponent(segment);
+
+const buildGeckoUrl = (config: GeckoCollectorConfig): URL => {
+  const url = new URL(
+    `/api/v2/networks/${encodeSegment(config.geckoNetwork)}/pools/${encodeSegment(
+      config.geckoPoolAddress
+    )}/ohlcv/hour`,
+    "https://api.geckoterminal.com"
+  );
+  url.search = new URLSearchParams({
+    aggregate: "1",
+    limit: String(config.geckoLookback)
+  }).toString();
+  return url;
+};
+
+const parseJson = async (response: Response): Promise<unknown> => {
+  try {
+    return await response.json();
+  } catch (error) {
+    throw new ProtocolError(
+      `GeckoTerminal returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+};
+
+const wrapFetchError = (error: unknown): never => {
+  if (
+    error instanceof DOMException &&
+    (error.name === "AbortError" || error.name === "TimeoutError")
+  ) {
+    throw new RequestTimeoutError();
+  }
+  if (error instanceof TypeError) {
+    throw new RequestTransportError(error.message);
+  }
+  throw error;
+};
+
+export async function fetchGeckoOhlcv(
+  config: GeckoCollectorConfig,
+  deps: GeckoFetchDeps
+): Promise<GeckoOhlcvPayload> {
+  await deps.waitForProviderPermit();
+
+  const fetchImpl = deps.fetch ?? fetch;
+  const signal =
+    deps.createTimeoutSignal?.(config.geckoRequestTimeoutMs) ??
+    AbortSignal.timeout(config.geckoRequestTimeoutMs);
+  let response: Response;
+
+  try {
+    response = await fetchImpl(buildGeckoUrl(config), {
+      headers: { Accept: "application/json" },
+      signal
+    });
+  } catch (error) {
+    wrapFetchError(error);
+  }
+
+  if (!response.ok) {
+    throw new HttpError({
+      statusCode: response.status,
+      responseBody: await response.text().catch(() => undefined),
+      retryable: isRetryableHttpStatus(response.status)
+    });
+  }
+
+  return parseJson(response);
+}
+```
+
+- [ ] **Step 4: Run Gecko client tests**
+
+Run:
+
+```bash
+pnpm exec vitest run src/workers/gecko/__tests__/geckoClient.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Gecko client**
+
+Run:
+
+```bash
+git add src/workers/gecko/geckoClient.ts src/workers/gecko/__tests__/geckoClient.test.ts
+git commit -m "feat: fetch Gecko OHLCV candles"
+```
+
+---
+
+### Task 5: Regime Engine Ingest Client
+
+**Files:**
+
+- Create: `src/workers/gecko/ingestClient.ts`
+- Test: `src/workers/gecko/__tests__/ingestClient.test.ts`
+
+- [ ] **Step 1: Write failing ingest client tests**
+
+Create `src/workers/gecko/__tests__/ingestClient.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import type { Candle } from "../../../contract/v1/types.js";
+import type { GeckoCollectorConfig } from "../config.js";
+import { postCandles } from "../ingestClient.js";
+import { HttpError, ProtocolError } from "../retry.js";
+
+const config: GeckoCollectorConfig = {
+  regimeEngineUrl: new URL("https://regime-engine.example/base"),
+  candlesIngestToken: "secret-token",
+  geckoSource: "geckoterminal",
+  geckoNetwork: "solana",
+  geckoPoolAddress: "pool",
+  geckoSymbol: "SOL/USDC",
+  geckoTimeframe: "1h",
+  geckoLookback: 200,
+  geckoPollIntervalMs: 300_000,
+  geckoMaxCallsPerMinute: 6,
+  geckoRequestTimeoutMs: 10_000
+};
+
+const candles: Candle[] = [
+  { unixMs: 3_600_000, open: 100, high: 110, low: 90, close: 105, volume: 1 }
+];
+
+const responseBody = {
+  schemaVersion: "1.0",
+  insertedCount: 1,
+  revisedCount: 0,
+  idempotentCount: 0,
+  rejectedCount: 0,
+  rejections: []
+};
+
+describe("postCandles", () => {
+  it("posts CandleIngestRequest with token header", async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify(responseBody), { status: 200 })
+    );
+
+    const result = await postCandles(config, candles, "2026-05-01T00:00:00.000Z", {
+      fetch: fetchMock,
+      createTimeoutSignal: () => undefined
+    });
+
+    expect(result.insertedCount).toBe(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe("https://regime-engine.example/v1/candles");
+    expect(init?.headers).toEqual({
+      "Content-Type": "application/json",
+      "X-Candles-Ingest-Token": "secret-token"
+    });
+    expect(JSON.parse(String(init?.body))).toEqual({
+      schemaVersion: "1.0",
+      source: "geckoterminal",
+      network: "solana",
+      poolAddress: "pool",
+      symbol: "SOL/USDC",
+      timeframe: "1h",
+      sourceRecordedAtIso: "2026-05-01T00:00:00.000Z",
+      candles
+    });
+  });
+
+  it("treats 200 with rejectedCount as success", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            ...responseBody,
+            insertedCount: 0,
+            rejectedCount: 1,
+            rejections: [
+              {
+                unixMs: 3_600_000,
+                reason: "STALE_REVISION",
+                existingSourceRecordedAtIso: "2026-05-01T01:00:00.000Z"
+              }
+            ]
+          }),
+          { status: 200 }
+        )
+    );
+
+    await expect(
+      postCandles(config, candles, "2026-05-01T00:00:00.000Z", {
+        fetch: fetchMock,
+        createTimeoutSignal: () => undefined
+      })
+    ).resolves.toMatchObject({ rejectedCount: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws retryable HttpError for 429 and 5xx", async () => {
+    for (const status of [429, 502]) {
+      const fetchMock = vi.fn(async () => new Response("error", { status }));
+      await expect(
+        postCandles(config, candles, "2026-05-01T00:00:00.000Z", {
+          fetch: fetchMock,
+          createTimeoutSignal: () => undefined
+        })
+      ).rejects.toMatchObject({ statusCode: status, retryable: true });
+    }
+  });
+
+  it("throws non-retryable HttpError for non-429 4xx", async () => {
+    const fetchMock = vi.fn(async () => new Response("bad token", { status: 401 }));
+    await expect(
+      postCandles(config, candles, "2026-05-01T00:00:00.000Z", {
+        fetch: fetchMock,
+        createTimeoutSignal: () => undefined
+      })
+    ).rejects.toMatchObject({ statusCode: 401, retryable: false });
+  });
+
+  it("throws ProtocolError for invalid response shape", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ...responseBody, schemaVersion: "2.0" }), { status: 200 })
+    );
+    await expect(
+      postCandles(config, candles, "2026-05-01T00:00:00.000Z", {
+        fetch: fetchMock,
+        createTimeoutSignal: () => undefined
+      })
+    ).rejects.toBeInstanceOf(ProtocolError);
+  });
+
+  it("throws ProtocolError when count fields are not non-negative integers", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ...responseBody, insertedCount: -1 }), {
+          status: 200
+        })
+    );
+    await expect(
+      postCandles(config, candles, "2026-05-01T00:00:00.000Z", {
+        fetch: fetchMock,
+        createTimeoutSignal: () => undefined
+      })
+    ).rejects.toBeInstanceOf(ProtocolError);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing ingest client tests**
+
+Run:
+
+```bash
+pnpm exec vitest run src/workers/gecko/__tests__/ingestClient.test.ts
+```
+
+Expected: FAIL because `src/workers/gecko/ingestClient.ts` does not exist.
+
+- [ ] **Step 3: Implement ingest client**
+
+Create `src/workers/gecko/ingestClient.ts` with strict response validation and no token logging:
+
+```ts
+import { SCHEMA_VERSION, type Candle, type CandleIngestResponse } from "../../contract/v1/types.js";
+import type { GeckoCollectorConfig } from "./config.js";
+import {
+  HttpError,
+  ProtocolError,
+  RequestTimeoutError,
+  RequestTransportError,
+  isRetryableHttpStatus
+} from "./retry.js";
+
+export type IngestClientDeps = {
+  fetch?: typeof fetch;
+  createTimeoutSignal?: (timeoutMs: number) => AbortSignal | undefined;
+};
+
+const nonNegativeInteger = (value: unknown): value is number => {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+};
+
+const validateResponse = (body: unknown): CandleIngestResponse => {
+  if (typeof body !== "object" || body === null) {
+    throw new ProtocolError("Invalid /v1/candles response object");
+  }
+  const record = body as Record<string, unknown>;
+  if (record.schemaVersion !== SCHEMA_VERSION) {
+    throw new ProtocolError("Invalid /v1/candles response schemaVersion");
+  }
+  for (const field of ["insertedCount", "revisedCount", "idempotentCount", "rejectedCount"]) {
+    if (!nonNegativeInteger(record[field])) {
+      throw new ProtocolError(`Invalid /v1/candles response ${field}`);
+    }
+  }
+  if (!Array.isArray(record.rejections)) {
+    throw new ProtocolError("Invalid /v1/candles response rejections");
+  }
+  for (const rejection of record.rejections) {
+    if (
+      typeof rejection !== "object" ||
+      rejection === null ||
+      !Number.isInteger((rejection as Record<string, unknown>).unixMs) ||
+      (rejection as Record<string, unknown>).reason !== "STALE_REVISION" ||
+      typeof (rejection as Record<string, unknown>).existingSourceRecordedAtIso !== "string"
+    ) {
+      throw new ProtocolError("Invalid /v1/candles rejection shape");
+    }
+  }
+  return body as CandleIngestResponse;
+};
+
+const wrapFetchError = (error: unknown): never => {
+  if (
+    error instanceof DOMException &&
+    (error.name === "AbortError" || error.name === "TimeoutError")
+  ) {
+    throw new RequestTimeoutError();
+  }
+  if (error instanceof TypeError) {
+    throw new RequestTransportError(error.message);
+  }
+  throw error;
+};
+
+export async function postCandles(
+  config: GeckoCollectorConfig,
+  candles: Candle[],
+  sourceRecordedAtIso: string,
+  deps: IngestClientDeps = {}
+): Promise<CandleIngestResponse> {
+  const url = new URL("/v1/candles", config.regimeEngineUrl);
+  const payload = {
+    schemaVersion: SCHEMA_VERSION,
+    source: config.geckoSource,
+    network: config.geckoNetwork,
+    poolAddress: config.geckoPoolAddress,
+    symbol: config.geckoSymbol,
+    timeframe: config.geckoTimeframe,
+    sourceRecordedAtIso,
+    candles
+  };
+  const signal =
+    deps.createTimeoutSignal?.(config.geckoRequestTimeoutMs) ??
+    AbortSignal.timeout(config.geckoRequestTimeoutMs);
+
+  let response: Response;
+  try {
+    response = await (deps.fetch ?? fetch)(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Candles-Ingest-Token": config.candlesIngestToken
+      },
+      body: JSON.stringify(payload),
+      signal
+    });
+  } catch (error) {
+    wrapFetchError(error);
+  }
+
+  if (!response.ok) {
+    throw new HttpError({
+      statusCode: response.status,
+      responseBody: await response.text().catch(() => undefined),
+      retryable: isRetryableHttpStatus(response.status)
+    });
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch (error) {
+    throw new ProtocolError(
+      `/v1/candles returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  return validateResponse(body);
+}
+```
+
+- [ ] **Step 4: Run ingest client tests**
+
+Run:
+
+```bash
+pnpm exec vitest run src/workers/gecko/__tests__/ingestClient.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit ingest client**
+
+Run:
+
+```bash
+git add src/workers/gecko/ingestClient.ts src/workers/gecko/__tests__/ingestClient.test.ts
+git commit -m "feat: post Gecko candles to regime engine"
+```
+
+---
+
+### Task 6: Collector Loop And ESM Entrypoint Guard
+
+**Files:**
+
+- Create: `src/workers/geckoCollector.ts`
+- Test: `src/workers/__tests__/geckoCollector.test.ts`
+
+- [ ] **Step 1: Write failing collector loop tests**
+
+Create `src/workers/__tests__/geckoCollector.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import type { GeckoCollectorConfig } from "../gecko/config.js";
+import { isMainModule, runOneCycle } from "../geckoCollector.js";
+
+const config: GeckoCollectorConfig = {
+  regimeEngineUrl: new URL("https://regime-engine.example"),
+  candlesIngestToken: "secret",
+  geckoSource: "geckoterminal",
+  geckoNetwork: "solana",
+  geckoPoolAddress: "pool",
+  geckoSymbol: "SOL/USDC",
+  geckoTimeframe: "1h",
+  geckoLookback: 1,
+  geckoPollIntervalMs: 300_000,
+  geckoMaxCallsPerMinute: 6,
+  geckoRequestTimeoutMs: 10_000
+};
+
+const payload = { data: { attributes: { ohlcv_list: [[3600, 100, 110, 90, 105, 1]] } } };
+
+describe("isMainModule", () => {
+  it("returns false for imported modules", () => {
+    expect(isMainModule("file:///repo/src/workers/geckoCollector.ts", "/repo/src/other.ts")).toBe(
+      false
+    );
+  });
+});
+
+describe("runOneCycle", () => {
+  it("fetches, normalizes, and posts using one sourceRecordedAtIso", async () => {
+    const postCandles = vi.fn(async () => ({
+      schemaVersion: "1.0" as const,
+      insertedCount: 1,
+      revisedCount: 0,
+      idempotentCount: 0,
+      rejectedCount: 0,
+      rejections: []
+    }));
+    await runOneCycle(config, {
+      fetchGeckoOhlcv: vi.fn(async () => payload),
+      postCandles,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      nowIso: () => "2026-05-01T00:00:00.000Z",
+      shouldContinue: () => true
+    });
+
+    expect(postCandles).toHaveBeenCalledWith(
+      config,
+      [{ unixMs: 3_600_000, open: 100, high: 110, low: 90, close: 105, volume: 1 }],
+      "2026-05-01T00:00:00.000Z",
+      expect.any(Object)
+    );
+  });
+
+  it("skips ingest when shutdown is requested after fetch", async () => {
+    const postCandles = vi.fn();
+    let calls = 0;
+    await runOneCycle(config, {
+      fetchGeckoOhlcv: vi.fn(async () => payload),
+      postCandles,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      nowIso: () => "2026-05-01T00:00:00.000Z",
+      shouldContinue: () => {
+        calls += 1;
+        return calls === 1;
+      }
+    });
+
+    expect(postCandles).not.toHaveBeenCalled();
+  });
+
+  it("logs and skips ingest when corruption guard blocks", async () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const rows = Array.from({ length: 20 }, (_, index) => [1 + index, 100, 110, 90, 105, 1]);
+    await runOneCycle(config, {
+      fetchGeckoOhlcv: vi.fn(async () => ({ data: { attributes: { ohlcv_list: rows } } })),
+      postCandles: vi.fn(),
+      logger,
+      nowIso: () => "2026-05-01T00:00:00.000Z",
+      shouldContinue: () => true
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "gecko_corruption_guard_blocked",
+      expect.objectContaining({ validCount: 0 })
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run failing collector tests**
+
+Run:
+
+```bash
+pnpm exec vitest run src/workers/__tests__/geckoCollector.test.ts
+```
+
+Expected: FAIL because `src/workers/geckoCollector.ts` does not exist.
+
+- [ ] **Step 3: Implement collector entrypoint**
+
+Create `src/workers/geckoCollector.ts`:
+
+```ts
+import { pathToFileURL } from "node:url";
+import { setTimeout as sleep } from "node:timers/promises";
+import { parseGeckoCollectorConfig, type GeckoCollectorConfig } from "./gecko/config.js";
+import { fetchGeckoOhlcv } from "./gecko/geckoClient.js";
+import { postCandles } from "./gecko/ingestClient.js";
+import { consoleLogger, type WorkerLogger } from "./gecko/logger.js";
+import { normalizeGeckoOhlcv, shouldPostNormalizedBatch } from "./gecko/normalize.js";
+import { createRateLimiter, withRetry } from "./gecko/retry.js";
+
+export type GeckoCollectorDeps = {
+  fetchGeckoOhlcv?: typeof fetchGeckoOhlcv;
+  postCandles?: typeof postCandles;
+  logger?: WorkerLogger;
+  nowIso?: () => string;
+  jitterMs?: (attempt: number) => number;
+  shouldContinue?: () => boolean;
+  waitForProviderPermit?: () => Promise<void>;
+};
+
+const defaultJitterMs = () => Math.floor(Math.random() * 250);
+
+const retryOptions = (shouldContinue: () => boolean, jitterMs: (attempt: number) => number) => ({
+  maxAttempts: 3,
+  initialBackoffMs: 1000,
+  maxBackoffMs: 30_000,
+  jitterMs,
+  sleep: (ms: number) => sleep(ms),
+  shouldContinue
+});
+
+export function isMainModule(importMetaUrl: string, argvPath: string | undefined): boolean {
+  return Boolean(argvPath && importMetaUrl === pathToFileURL(argvPath).href);
+}
+
+export async function runOneCycle(
+  config: GeckoCollectorConfig,
+  deps: GeckoCollectorDeps = {}
+): Promise<void> {
+  const logger = deps.logger ?? consoleLogger;
+  const shouldContinue = deps.shouldContinue ?? (() => true);
+  const jitterMs = deps.jitterMs ?? defaultJitterMs;
+  const fetchClient = deps.fetchGeckoOhlcv ?? fetchGeckoOhlcv;
+  const ingestClient = deps.postCandles ?? postCandles;
+
+  logger.info("gecko_cycle_started", {
+    provider: config.geckoSource,
+    network: config.geckoNetwork,
+    poolAddress: config.geckoPoolAddress,
+    symbol: config.geckoSymbol,
+    timeframe: config.geckoTimeframe
+  });
+
+  const payload = await withRetry(
+    () =>
+      fetchClient(config, {
+        waitForProviderPermit: deps.waitForProviderPermit ?? (async () => {})
+      }),
+    retryOptions(shouldContinue, jitterMs)
+  );
+
+  if (!shouldContinue()) return;
+
+  const sourceRecordedAtIso = deps.nowIso?.() ?? new Date().toISOString();
+  const normalized = normalizeGeckoOhlcv(payload, config);
+
+  if (!shouldContinue()) return;
+
+  if (!shouldPostNormalizedBatch(normalized.stats, config)) {
+    logger.warn("gecko_corruption_guard_blocked", normalized.stats);
+    return;
+  }
+
+  const response = await withRetry(
+    () => ingestClient(config, normalized.validCandles, sourceRecordedAtIso),
+    retryOptions(shouldContinue, jitterMs)
+  );
+
+  logger.info("gecko_ingest_succeeded", {
+    insertedCount: response.insertedCount,
+    revisedCount: response.revisedCount,
+    idempotentCount: response.idempotentCount,
+    rejectedCount: response.rejectedCount,
+    candleCountFetched: normalized.stats.providerRowCount,
+    candleCountPosted: normalized.validCandles.length,
+    sourceRecordedAtIso
+  });
+
+  if (response.rejectedCount > 0) {
+    logger.warn("gecko_ingest_stale_revisions", {
+      rejectedCount: response.rejectedCount,
+      sourceRecordedAtIso
+    });
+  }
+}
+
+export async function runCollector(config = parseGeckoCollectorConfig()): Promise<void> {
+  const shutdown = new AbortController();
+  let shutdownRequested = false;
+  const logger = consoleLogger;
+  const waitForProviderPermit = createRateLimiter(config.geckoMaxCallsPerMinute);
+
+  const requestShutdown = (signal: string) => {
+    shutdownRequested = true;
+    logger.info("gecko_collector_shutdown_requested", { signal });
+    shutdown.abort();
+  };
+
+  process.once("SIGTERM", () => requestShutdown("SIGTERM"));
+  process.once("SIGINT", () => requestShutdown("SIGINT"));
+
+  logger.info("gecko_collector_started", {
+    provider: config.geckoSource,
+    network: config.geckoNetwork,
+    poolAddress: config.geckoPoolAddress,
+    symbol: config.geckoSymbol,
+    timeframe: config.geckoTimeframe
+  });
+
+  while (!shutdownRequested) {
+    try {
+      await runOneCycle(config, {
+        logger,
+        waitForProviderPermit,
+        shouldContinue: () => !shutdownRequested
+      });
+    } catch (error) {
+      logger.error("gecko_cycle_failed", {
+        errorMessage: error instanceof Error ? error.message : String(error)
+      });
+    }
+
+    if (shutdownRequested) break;
+    try {
+      await sleep(config.geckoPollIntervalMs, undefined, { signal: shutdown.signal });
+    } catch {
+      break;
+    }
+  }
+
+  logger.info("gecko_collector_shutdown_complete");
+}
+
+if (isMainModule(import.meta.url, process.argv[1])) {
+  void runCollector().catch((error) => {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        event: "gecko_collector_fatal",
+        errorMessage: error instanceof Error ? error.message : String(error)
+      })
+    );
+    process.exit(1);
+  });
+}
+```
+
+- [ ] **Step 4: Run collector tests**
+
+Run:
+
+```bash
+pnpm exec vitest run src/workers/__tests__/geckoCollector.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run all worker tests**
+
+Run:
+
+```bash
+pnpm exec vitest run src/workers/gecko/__tests__ src/workers/__tests__
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit collector loop**
+
+Run:
+
+```bash
+git add src/workers/geckoCollector.ts src/workers/__tests__/geckoCollector.test.ts
+git commit -m "feat: add Gecko collector loop"
+```
+
+---
+
+### Task 7: Package Scripts, Env Example, And Deployment Docs
+
+**Files:**
+
+- Modify: `package.json`
+- Modify: `.env.example`
+- Modify: `README.md`
+- Modify: `docs/runbooks/railway-deploy.md`
+- Test: add package-script assertion to `src/workers/__tests__/geckoCollector.test.ts`
+
+- [ ] **Step 1: Add package script assertion**
+
+Append this test to `src/workers/__tests__/geckoCollector.test.ts`:
+
+```ts
+import { readFileSync } from "node:fs";
+
+describe("package scripts", () => {
+  it("points start scripts at dist/src outputs", () => {
+    const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
+      scripts: Record<string, string>;
+    };
+
+    expect(packageJson.scripts.start).toBe("node --env-file-if-exists=.env dist/src/server.js");
+    expect(packageJson.scripts["dev:gecko"]).toBe("tsx watch src/workers/geckoCollector.ts");
+    expect(packageJson.scripts["start:gecko"]).toBe(
+      "node --env-file-if-exists=.env dist/src/workers/geckoCollector.js"
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run failing package script assertion**
+
+Run:
+
+```bash
+pnpm exec vitest run src/workers/__tests__/geckoCollector.test.ts
+```
+
+Expected: FAIL because `package.json` does not yet have the required scripts.
+
+- [ ] **Step 3: Modify `package.json` scripts**
+
+Update the `scripts` block so it includes these exact entries while preserving existing scripts:
+
+```json
+{
+  "dev": "tsx watch src/server.ts",
+  "start": "node --env-file-if-exists=.env dist/src/server.js",
+  "dev:gecko": "tsx watch src/workers/geckoCollector.ts",
+  "start:gecko": "node --env-file-if-exists=.env dist/src/workers/geckoCollector.js"
+}
+```
+
+Do not remove existing `build`, `typecheck`, `lint`, `test`, `test:watch`, `test:pg`, `format`, `harness`, `db:migrate`, `db:generate`, `db:push`, or `prepare`.
+
+- [ ] **Step 4: Add worker env vars to `.env.example`**
+
+Append this block to `.env.example`:
+
+```text
+# GeckoTerminal candle collector worker
+REGIME_ENGINE_URL=https://<regime-engine-service>
+CANDLES_INGEST_TOKEN=
+GECKO_SOURCE=geckoterminal
+GECKO_NETWORK=solana
+GECKO_POOL_ADDRESS=<confirm-before-production>
+GECKO_SYMBOL=SOL/USDC
+GECKO_TIMEFRAME=1h
+GECKO_LOOKBACK=200
+GECKO_POLL_INTERVAL_MS=300000
+GECKO_MAX_CALLS_PER_MINUTE=6
+GECKO_REQUEST_TIMEOUT_MS=10000
+```
+
+- [ ] **Step 5: Update README**
+
+Add a `## GeckoTerminal candle collector` section after the endpoint list:
+
+````md
+## GeckoTerminal candle collector
+
+The GeckoTerminal collector is a separate worker service from the same repo. It
+does not start Fastify and does not write SQLite or Postgres directly. It fetches
+the configured Solana SOL/USDC GeckoTerminal pool and posts normalized `1h`
+candles to `POST /v1/candles` with `X-Candles-Ingest-Token`.
+
+Local commands:
+
+```bash
+npm run dev:gecko
+npm run start:gecko
+```
+
+Worker env vars:
+
+| Variable                     | Default         | Notes                                                                    |
+| ---------------------------- | --------------- | ------------------------------------------------------------------------ |
+| `REGIME_ENGINE_URL`          | -               | Absolute URL for the regime-engine web service.                          |
+| `CANDLES_INGEST_TOKEN`       | -               | Shared secret sent as `X-Candles-Ingest-Token`.                          |
+| `GECKO_SOURCE`               | `geckoterminal` | Must equal `geckoterminal` for MVP.                                      |
+| `GECKO_NETWORK`              | `solana`        | Must equal `solana` for MVP.                                             |
+| `GECKO_POOL_ADDRESS`         | -               | Explicit GeckoTerminal SOL/USDC pool address. Confirm before production. |
+| `GECKO_SYMBOL`               | `SOL/USDC`      | Must equal `SOL/USDC` for MVP.                                           |
+| `GECKO_TIMEFRAME`            | `1h`            | Must equal `1h` for MVP.                                                 |
+| `GECKO_LOOKBACK`             | `200`           | Rolling candle window size.                                              |
+| `GECKO_POLL_INTERVAL_MS`     | `300000`        | Sleep after each completed cycle.                                        |
+| `GECKO_MAX_CALLS_PER_MINUTE` | `6`             | Provider-scoped GeckoTerminal call cap.                                  |
+| `GECKO_REQUEST_TIMEOUT_MS`   | `10000`         | Per-request timeout for provider and ingest calls.                       |
+
+Railway services from the same repo:
+
+| Service                         | Build        | Start              |
+| ------------------------------- | ------------ | ------------------ |
+| `regime-engine-web`             | `pnpm build` | `pnpm start`       |
+| `regime-engine-gecko-collector` | `pnpm build` | `pnpm start:gecko` |
+
+Production checklist:
+
+- [ ] Confirm the canonical GeckoTerminal Solana SOL/USDC pool address before
+      setting `GECKO_POOL_ADDRESS`.
+````
+
+- [ ] **Step 6: Update Railway runbook**
+
+Add a section after the web service deployment env vars:
+
+```md
+## GeckoTerminal collector Railway service
+
+Create a second service from the same repo:
+
+| Setting       | Value                           |
+| ------------- | ------------------------------- |
+| Service name  | `regime-engine-gecko-collector` |
+| Build command | `pnpm build`                    |
+| Start command | `pnpm start:gecko`              |
+
+Do not change `railway.toml` for the collector. The web service continues to use
+`pnpm start`; the collector uses a Railway service start-command override.
+
+Collector env vars:
+
+| Variable                     | Value                                                 |
+| ---------------------------- | ----------------------------------------------------- |
+| `REGIME_ENGINE_URL`          | Railway private or public URL for `regime-engine-web` |
+| `CANDLES_INGEST_TOKEN`       | same value as web service `CANDLES_INGEST_TOKEN`      |
+| `GECKO_SOURCE`               | `geckoterminal`                                       |
+| `GECKO_NETWORK`              | `solana`                                              |
+| `GECKO_POOL_ADDRESS`         | confirmed GeckoTerminal SOL/USDC pool address         |
+| `GECKO_SYMBOL`               | `SOL/USDC`                                            |
+| `GECKO_TIMEFRAME`            | `1h`                                                  |
+| `GECKO_LOOKBACK`             | `200`                                                 |
+| `GECKO_POLL_INTERVAL_MS`     | `300000`                                              |
+| `GECKO_MAX_CALLS_PER_MINUTE` | `6`                                                   |
+| `GECKO_REQUEST_TIMEOUT_MS`   | `10000`                                               |
+
+Before production:
+
+- [ ] Confirm and record the canonical GeckoTerminal Solana SOL/USDC pool address.
+- [ ] Confirm the collector can reach `REGIME_ENGINE_URL`.
+- [ ] Confirm the web service and collector share the same `CANDLES_INGEST_TOKEN`.
+```
+
+- [ ] **Step 7: Run package/docs checks**
+
+Run:
+
+```bash
+pnpm exec vitest run src/workers/__tests__/geckoCollector.test.ts
+pnpm exec prettier --check package.json .env.example README.md docs/runbooks/railway-deploy.md
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit scripts and docs**
+
+Run:
+
+```bash
+git add package.json .env.example README.md docs/runbooks/railway-deploy.md src/workers/__tests__/geckoCollector.test.ts
+git commit -m "docs: document Gecko collector deployment"
+```
+
+---
+
+### Task 8: Full Validation Gate
+
+**Files:**
+
+- Validate all changed files.
+
+- [ ] **Step 1: Run worker test suite**
+
+Run:
+
+```bash
+pnpm exec vitest run src/workers/gecko/__tests__ src/workers/__tests__
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full unit test suite**
+
+Run:
+
+```bash
+pnpm run test
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run TypeScript checks**
+
+Run:
+
+```bash
+pnpm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run lint**
+
+Run:
+
+```bash
+pnpm run lint
+```
+
+Expected: PASS with zero warnings.
+
+- [ ] **Step 5: Run build**
+
+Run:
+
+```bash
+pnpm run build
+```
+
+Expected: PASS and emits `dist/src/workers/geckoCollector.js`.
+
+- [ ] **Step 6: Verify built worker path**
+
+Run:
+
+```bash
+test -f dist/src/workers/geckoCollector.js
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 7: Run final quality gate**
+
+Run:
+
+```bash
+pnpm run typecheck && pnpm run test && pnpm run lint && pnpm run build
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Confirm validation did not create accidental file changes**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no output. If this shows changed files, inspect them and either commit intentional generated artifacts with a specific file list or remove accidental local artifacts before handing off.
+
+---
+
+## Self-Review Notes
+
+Spec coverage:
+
+- Worker entrypoint: Task 6.
+- Config validation and defaults: Task 1.
+- Gecko fetch URL, headers, HTTP error conversion, timeout wrapping: Task 4.
+- Provider-scoped rate limiter created once and reused: Tasks 2 and 6.
+- Retry/backoff with injectable jitter and non-retryable protocol/programmer errors: Task 2.
+- Normalization, duplicate handling, and corruption guard: Task 3.
+- Controlled skipped-ingest cycle: Tasks 3 and 6.
+- Ingest POST payload, token header, strict response shape, stale revision warning semantics: Task 5.
+- ESM import guard: Task 6.
+- Secret redaction: Tasks 1 and 5.
+- Scripts, `.env.example`, README, Railway runbook: Task 7.
+- Quality gate: Task 8.
+
+No implementation task imports or modifies Fastify app, route registration, ledger stores, candle writers, Postgres DB modules, or `railway.toml`.

--- a/docs/superpowers/specs/2026-05-01-gecko-terminal-collector-design.md
+++ b/docs/superpowers/specs/2026-05-01-gecko-terminal-collector-design.md
@@ -152,7 +152,7 @@ Hard-required env:
 | ---------------------- | ------------------------------------------------------------ |
 | `REGIME_ENGINE_URL`    | absolute URL; HTTPS unless localhost or Railway private host |
 | `CANDLES_INGEST_TOKEN` | non-empty                                                    |
-| `GECKO_POOL_ADDRESS`   | explicit non-empty; do not infer                             |
+| `GECKO_POOL_ADDRESS`   | explicit non-empty; no placeholder values or angle brackets  |
 
 Defaulted env, validated if present:
 
@@ -162,7 +162,7 @@ Defaulted env, validated if present:
 | `GECKO_NETWORK`              | `solana`        | must equal `solana`        |
 | `GECKO_SYMBOL`               | `SOL/USDC`      | must equal `SOL/USDC`      |
 | `GECKO_TIMEFRAME`            | `1h`            | must equal `1h`            |
-| `GECKO_LOOKBACK`             | `200`           | positive integer           |
+| `GECKO_LOOKBACK`             | `200`           | positive integer `<= 1000` |
 | `GECKO_POLL_INTERVAL_MS`     | `300000`        | positive integer           |
 | `GECKO_MAX_CALLS_PER_MINUTE` | `6`             | positive integer           |
 | `GECKO_REQUEST_TIMEOUT_MS`   | `10000`         | positive integer           |
@@ -503,7 +503,7 @@ Per-row validation:
 - each row must have length exactly `6`; missing fields or extra fields are
   malformed
 - `timestampSeconds` is an integer
-- `timestampSeconds` and normalized `unixMs` must be safe integers
+- `timestampSeconds` and normalized `unixMs` must be safe non-negative integers
 - `unixMs` is an integer aligned to the 1h boundary
 - `open`, `high`, `low`, and `close` are finite and `> 0`
 - `volume` is finite and `>= 0`
@@ -723,9 +723,11 @@ Config parser:
 - rejects explicit empty optional env vars instead of silently defaulting
 - missing token
 - missing pool address
-- invalid positive integers
+- placeholder pool addresses with `<` or `>` are rejected
+- invalid numeric env values, including `GECKO_LOOKBACK=1001`
 - wrong network/timeframe/source
 - `GECKO_SYMBOL` defaults to `SOL/USDC` and rejects any other value
+- logger redacts top-level and nested token, header, and response body fields
 
 Gecko client:
 
@@ -750,7 +752,7 @@ Normalizer:
 - 1h timestamp alignment
 - non-array rows are malformed
 - rows with `length !== 6` are malformed, including missing or extra fields
-- timestamps must be safe integers
+- timestamps must be safe non-negative integers
 - payloads with more than 1000 OHLCV rows fail before iteration
 - malformed rows dropped
 - invalid OHLCV rows dropped
@@ -773,6 +775,8 @@ Ingest client:
 - response validates `schemaVersion === "1.0"` and all count fields as
   non-negative integers
 - invalid response JSON is `ProtocolError`
+- timeout aborts become `RequestTimeoutError`
+- network/transport failures become `RequestTransportError`
 
 Retry helper:
 

--- a/docs/superpowers/specs/2026-05-01-gecko-terminal-collector-design.md
+++ b/docs/superpowers/specs/2026-05-01-gecko-terminal-collector-design.md
@@ -1,0 +1,682 @@
+# GeckoTerminal Candle Collector Design
+
+- **Issue:** [#18](https://github.com/opsclawd/regime-engine/issues/18)
+- **Date:** 2026-05-01
+- **Status:** Approved design, pending written-spec review
+- **Target repo:** `regime-engine`
+
+## Problem
+
+`regime-engine` already owns candle ingestion through `POST /v1/candles` and
+market-regime reads through `GET /v1/regime/current`. The missing piece is an
+external producer that fetches SOL/USDC 1h OHLCV candles from GeckoTerminal and
+posts normalized batches to the existing candle ingest endpoint.
+
+The collector must live in this repo for deployment convenience, but it must
+behave like a separate service:
+
+- no Fastify app startup
+- no direct SQLite or Postgres writes
+- no imports from `src/app.ts`, `src/server.ts`, `src/http/routes.ts`,
+  `src/ledger/store.ts`, `src/ledger/candleStore.ts`,
+  `src/ledger/candlesWriter.ts`, or `src/ledger/pg/db.ts`
+- only HTTP interaction with `regime-engine`: `POST /v1/candles`
+
+Provider docs checked during design:
+
+- GeckoTerminal API getting started: <https://apiguide.geckoterminal.com/getting-started>
+- GeckoTerminal API authentication: <https://apiguide.geckoterminal.com/authentication>
+- GeckoTerminal pool OHLCV reference: <https://docs.coingecko.com/reference/pool-ohlcv-contract-address>
+- GeckoTerminal FAQ / public limits: <https://apiguide.geckoterminal.com/faq>
+
+## Goals
+
+- Add a separate GeckoTerminal collector worker entrypoint.
+- Use zero new runtime dependencies.
+- Use built-in Node 22 APIs: global `fetch`, `AbortController`, and
+  `node:timers/promises`.
+- Fetch a configured Solana SOL/USDC GeckoTerminal pool.
+- Fetch only `1h` candles for MVP.
+- Fetch a rolling 200-candle window by default.
+- Normalize Gecko Unix-second OHLCV rows into the existing candle ingest
+  contract, which uses Unix milliseconds.
+- Validate and dedupe provider rows locally before POSTing.
+- Use a corruption guard to avoid posting when the provider shape or data
+  quality looks broken.
+- POST to `/v1/candles` with `X-Candles-Ingest-Token`.
+- Use bounded local retry/backoff and provider-scoped rate limiting.
+- Run a sequential immediate-start loop with graceful Railway shutdown.
+- Document the two-service Railway deployment model.
+
+## Non-goals
+
+- No provider registry.
+- No generic collector framework.
+- No future-timeframe abstraction.
+- No pool discovery or rotation.
+- No Birdeye, CoinGecko paid API, websocket ingestion, or on-chain aggregation.
+- No changes to `/v1/candles` or `/v1/regime/current`.
+- No on-chain execution code.
+
+## Module Boundaries
+
+Add a small worker slice:
+
+```text
+src/workers/geckoCollector.ts
+src/workers/gecko/config.ts
+src/workers/gecko/geckoClient.ts
+src/workers/gecko/normalize.ts
+src/workers/gecko/ingestClient.ts
+src/workers/gecko/retry.ts
+src/workers/gecko/logger.ts
+```
+
+Allowed shared imports are limited to contract types/constants such as
+`Candle`, `CandleIngestResponse`, and `SCHEMA_VERSION`.
+
+### `src/workers/geckoCollector.ts`
+
+Responsibilities:
+
+- parse config by calling `parseGeckoCollectorConfig(process.env)`
+- install `SIGTERM` and `SIGINT` handlers
+- run one cycle immediately on startup
+- sleep after each completed or failed cycle
+- prevent overlapping cycles by using a sequential async loop
+- check shutdown state between phases
+
+Exports:
+
+```ts
+export function runOneCycle(config: GeckoCollectorConfig, deps?: GeckoCollectorDeps): Promise<void>;
+
+export function runCollector(
+  config?: GeckoCollectorConfig,
+  deps?: GeckoCollectorDeps
+): Promise<void>;
+```
+
+`GeckoCollectorDeps` is only a test seam for logger, sleep, now, fetch/random
+indirection where needed. It is not a framework.
+
+### `src/workers/gecko/config.ts`
+
+Responsibilities:
+
+- parse env vars
+- apply defaults
+- validate MVP constraints
+- fail fast with clear config errors
+
+Exports:
+
+```ts
+export type GeckoCollectorConfig = {
+  regimeEngineUrl: URL;
+  candlesIngestToken: string;
+  geckoSource: "geckoterminal";
+  geckoNetwork: "solana";
+  geckoPoolAddress: string;
+  geckoSymbol: string;
+  geckoTimeframe: "1h";
+  geckoLookback: number;
+  geckoPollIntervalMs: number;
+  geckoMaxCallsPerMinute: number;
+  geckoRequestTimeoutMs: number;
+};
+
+export function parseGeckoCollectorConfig(env?: NodeJS.ProcessEnv): GeckoCollectorConfig;
+```
+
+Hard-required env:
+
+| Variable               | Rule                             |
+| ---------------------- | -------------------------------- |
+| `REGIME_ENGINE_URL`    | absolute URL                     |
+| `CANDLES_INGEST_TOKEN` | non-empty                        |
+| `GECKO_POOL_ADDRESS`   | explicit non-empty; do not infer |
+
+Defaulted env, validated if present:
+
+| Variable                     | Default         | Rule                       |
+| ---------------------------- | --------------- | -------------------------- |
+| `GECKO_SOURCE`               | `geckoterminal` | must equal `geckoterminal` |
+| `GECKO_NETWORK`              | `solana`        | must equal `solana`        |
+| `GECKO_SYMBOL`               | `SOL/USDC`      | non-empty                  |
+| `GECKO_TIMEFRAME`            | `1h`            | must equal `1h`            |
+| `GECKO_LOOKBACK`             | `200`           | positive integer           |
+| `GECKO_POLL_INTERVAL_MS`     | `300000`        | positive integer           |
+| `GECKO_MAX_CALLS_PER_MINUTE` | `6`             | positive integer           |
+| `GECKO_REQUEST_TIMEOUT_MS`   | `10000`         | positive integer           |
+
+### `src/workers/gecko/geckoClient.ts`
+
+Responsibilities:
+
+- build the GeckoTerminal OHLCV URL
+- apply the provider-scoped rate limiter before each provider call
+- fetch with a per-request timeout controller
+- convert non-OK HTTP responses into typed `HttpError`s
+- parse and return JSON as `unknown`
+
+Exports:
+
+```ts
+export type GeckoOhlcvPayload = unknown;
+
+export function fetchGeckoOhlcv(
+  config: GeckoCollectorConfig,
+  deps?: GeckoFetchDeps
+): Promise<GeckoOhlcvPayload>;
+```
+
+The provider URL is assembled with `URL` and `URLSearchParams`, not raw string
+interpolation. Path segments are encoded:
+
+```text
+https://api.geckoterminal.com/api/v2/networks/{network}/pools/{poolAddress}/ohlcv/hour?aggregate=1&limit={GECKO_LOOKBACK}
+```
+
+For MVP, `GECKO_TIMEFRAME=1h` maps to Gecko `hour` with `aggregate=1`.
+The request sends `Accept: application/json`. GeckoTerminal public API access
+does not require provider authentication for this MVP path.
+
+### `src/workers/gecko/normalize.ts`
+
+Responsibilities:
+
+- treat provider JSON as untrusted `unknown`
+- accept only the documented OHLCV list shape
+- convert Unix seconds to Unix milliseconds
+- validate rows independently
+- handle duplicate timestamps
+- sort final candles by `unixMs ASC`
+- produce structured stats and corruption-guard decisions
+
+Exports:
+
+```ts
+export type NormalizationStats = {
+  providerRowCount: number;
+  malformedRowCount: number;
+  misalignedRowCount: number;
+  invalidOhlcvRowCount: number;
+  duplicateIdenticalDroppedCount: number;
+  duplicateConflictDroppedCount: number;
+  totalDroppedCount: number;
+  corruptionDroppedCount: number;
+  validCount: number;
+  dropReasons: Record<string, number>;
+};
+
+export type NormalizationResult = {
+  validCandles: Candle[];
+  stats: NormalizationStats;
+};
+
+export function normalizeGeckoOhlcv(
+  payload: unknown,
+  config: GeckoCollectorConfig
+): NormalizationResult;
+
+export function shouldPostNormalizedBatch(
+  stats: NormalizationStats,
+  config: GeckoCollectorConfig
+): boolean;
+```
+
+### `src/workers/gecko/ingestClient.ts`
+
+Responsibilities:
+
+- build the `CandleIngestRequest`
+- POST to `/v1/candles`
+- send `X-Candles-Ingest-Token`
+- fetch with a per-request timeout controller
+- convert non-OK HTTP responses into typed `HttpError`s
+- validate the expected ingest response shape
+- treat `200` with `rejectedCount > 0` as success with warning, not retry
+
+Exports:
+
+```ts
+export function postCandles(
+  config: GeckoCollectorConfig,
+  candles: Candle[],
+  sourceRecordedAtIso: string,
+  deps?: IngestClientDeps
+): Promise<CandleIngestResponse>;
+```
+
+`sourceRecordedAtIso` is set once per successfully fetched batch and reused
+across ingest retries.
+
+### `src/workers/gecko/retry.ts`
+
+Responsibilities:
+
+- retry small async operations with bounded exponential backoff
+- expose retryable HTTP classification
+- expose provider-scoped rate limiter
+- keep jitter injectable for deterministic tests
+
+Exports:
+
+```ts
+export class HttpError extends Error {
+  statusCode: number;
+  responseBody?: string;
+  retryable: boolean;
+}
+
+export class ProtocolError extends Error {}
+export class RequestTimeoutError extends Error {}
+
+export type RetryOptions = {
+  maxAttempts: number;
+  initialBackoffMs: number;
+  maxBackoffMs: number;
+  jitterMs: (attempt: number) => number;
+  sleep: typeof import("node:timers/promises").setTimeout;
+  shouldContinue?: () => boolean;
+};
+
+export function withRetry<T>(
+  operation: (attempt: number) => Promise<T>,
+  options: RetryOptions
+): Promise<T>;
+
+export function createRateLimiter(
+  maxCallsPerMinute: number,
+  sleep?: typeof import("node:timers/promises").setTimeout
+): () => Promise<void>;
+
+export function isRetryableHttpStatus(status: number): boolean;
+```
+
+`createRateLimiter` is only for GeckoTerminal provider calls. It is not applied
+to `/v1/candles` ingest POSTs.
+
+### `src/workers/gecko/logger.ts`
+
+Responsibilities:
+
+- provide minimal structured console helpers or a small injected logger type
+- no logging framework
+- no runtime dependency
+- no generic observability layer
+
+## Collector Lifecycle
+
+The worker starts by parsing env. Config errors are fatal and exit nonzero.
+Runtime cycle failures log and continue after the configured sleep interval.
+
+Sequential loop:
+
+```ts
+while (!shutdownRequested) {
+  await runOneCycle(config);
+  await sleep(config.geckoPollIntervalMs, undefined, { signal: shutdownSleepSignal });
+}
+```
+
+The first cycle runs immediately on startup. The worker does not wait one full
+interval before proving env, provider access, normalization, ingest auth, and
+`regime-engine` connectivity.
+
+`runOneCycle`:
+
+```text
+1. Log gecko_cycle_started.
+2. Fetch Gecko OHLCV with provider rate limit, timeout, and retry.
+3. If shutdown was requested during fetch, return before normalization or ingest.
+4. Set sourceRecordedAtIso once for the fetched batch.
+5. Normalize, validate, dedupe, and sort candles.
+6. If shutdown was requested after normalization, return before ingest.
+7. Apply zero-valid and corruption guards.
+8. POST valid candles to /v1/candles with timeout and retry.
+9. Log ingest counts and cycle completion.
+```
+
+Shutdown rules:
+
+- SIGTERM/SIGINT during sleep: abort sleep and exit.
+- SIGTERM/SIGINT during Gecko fetch: let fetch finish or hit request timeout,
+  then return without starting ingest.
+- SIGTERM/SIGINT during ingest POST: let ingest finish or hit request timeout,
+  then exit.
+- Never start another cycle after shutdown.
+
+The shutdown signal prevents new phases and cycles. It is not passed directly
+to in-flight fetch/ingest requests, because those requests should complete or
+hit their own request timeout.
+
+Fetch and ingest clients create their own per-request timeout controllers. If
+shutdown is requested during a retry backoff, the collector should not start the
+next provider or ingest attempt.
+
+## Retry, Rate Limit, And HTTP Errors
+
+Use local helpers only.
+
+Retry policy for Gecko fetch and ingest POST:
+
+| Rule            | Value                                                      |
+| --------------- | ---------------------------------------------------------- |
+| max attempts    | 3                                                          |
+| initial backoff | 1000ms                                                     |
+| max backoff     | 30000ms                                                    |
+| formula         | `initialBackoffMs * 2 ** (attempt - 1)` capped at max      |
+| jitter          | bounded and injectable/mocked in tests                     |
+| retry           | HTTP 429, HTTP 5xx, network error, request timeout         |
+| no retry        | non-429 HTTP 4xx                                           |
+| no retry        | successful `/v1/candles` response with `rejectedCount > 0` |
+
+`fetch` does not throw for HTTP failures, so clients must convert responses:
+
+- `429` and `5xx` become retryable `HttpError`s.
+- non-429 `4xx` becomes non-retryable `HttpError`.
+- `2xx` with invalid JSON or unexpected response shape becomes `ProtocolError`
+  and fails the cycle.
+- network errors and request timeouts are retryable until attempts are
+  exhausted.
+
+Provider rate limiting:
+
+- scoped only to GeckoTerminal provider calls
+- first provider call is immediate
+- retries are also provider calls and are rate limited
+- one provider request is in flight at a time
+- subsequent provider calls are spaced by at least
+  `60000 / GECKO_MAX_CALLS_PER_MINUTE` milliseconds
+- default `GECKO_MAX_CALLS_PER_MINUTE=6`, so at most one provider call every
+  10 seconds after the first call
+
+## Normalization And Corruption Guard
+
+The normalizer reads the documented GeckoTerminal envelope:
+
+```text
+payload.data.attributes.ohlcv_list
+```
+
+It accepts rows shaped as:
+
+```text
+[timestampSeconds, open, high, low, close, volume]
+```
+
+Conversion:
+
+```text
+unixMs = timestampSeconds * 1000
+```
+
+Per-row validation:
+
+- `timestampSeconds` is an integer
+- `unixMs` is an integer aligned to the 1h boundary
+- `open`, `high`, `low`, and `close` are finite and `> 0`
+- `volume` is finite and `>= 0`
+- `high >= max(open, close, low)`
+- `low <= min(open, close, high)`
+
+Malformed top-level provider envelopes, missing OHLCV lists, and non-array
+OHLCV lists are protocol failures. They fail the cycle and do not POST.
+
+Parseable rows are validated independently:
+
+- malformed, misaligned, or invalid-OHLCV rows are dropped locally
+- exact duplicate rows are deduped
+- conflicting duplicate timestamps drop all rows for that timestamp
+- final valid candles are sorted by `unixMs ASC`
+
+Duplicate policy:
+
+| Case                                | Behavior                                                                      |
+| ----------------------------------- | ----------------------------------------------------------------------------- |
+| same `unixMs` and identical OHLCV   | keep one, count `duplicateIdenticalDroppedCount`, warn                        |
+| same `unixMs` and conflicting OHLCV | drop all rows for that timestamp, count `duplicateConflictDroppedCount`, warn |
+
+Dropped-count accounting:
+
+```text
+totalDroppedCount =
+  malformedRowCount +
+  misalignedRowCount +
+  invalidOhlcvRowCount +
+  duplicateIdenticalDroppedCount +
+  duplicateConflictDroppedCount
+
+corruptionDroppedCount =
+  malformedRowCount +
+  misalignedRowCount +
+  invalidOhlcvRowCount +
+  duplicateConflictDroppedCount
+```
+
+Exact duplicate rows do not trigger the corruption guard by themselves because
+they do not change candle truth after dedupe.
+
+Posting guard:
+
+```ts
+if (validCount === 0) {
+  warn and skip POST;
+}
+
+if (providerRowCount > 0 && corruptionDroppedCount / providerRowCount > 0.10) {
+  warn and fail cycle without POST;
+}
+
+if (config.geckoLookback >= 50 && validCount < 50) {
+  warn and fail cycle without POST;
+}
+```
+
+The worker posts the valid subset only when the guard passes.
+
+## Ingest POST
+
+`ingestClient.ts` builds the existing contract:
+
+```ts
+{
+  schemaVersion: SCHEMA_VERSION,
+  source: config.geckoSource,
+  network: config.geckoNetwork,
+  poolAddress: config.geckoPoolAddress,
+  symbol: config.geckoSymbol,
+  timeframe: "1h",
+  sourceRecordedAtIso,
+  candles
+}
+```
+
+The URL is built with `new URL("/v1/candles", config.regimeEngineUrl)`.
+
+Headers:
+
+```text
+Content-Type: application/json
+X-Candles-Ingest-Token: <CANDLES_INGEST_TOKEN>
+```
+
+Successful response logging includes:
+
+- `insertedCount`
+- `revisedCount`
+- `idempotentCount`
+- `rejectedCount`
+- `candleCountFetched`
+- `candleCountPosted`
+- `sourceRecordedAtIso`
+
+`rejectedCount > 0` is a warning because stale historical revisions can be
+normal. It is not retryable.
+
+## Logging
+
+Use compact structured console output or an injected logger type. Events:
+
+- `gecko_collector_started`
+- `gecko_cycle_started`
+- `gecko_fetch_failed`
+- `gecko_fetch_succeeded`
+- `gecko_normalization_warn`
+- `gecko_corruption_guard_blocked`
+- `gecko_ingest_failed`
+- `gecko_ingest_succeeded`
+- `gecko_cycle_failed`
+- `gecko_cycle_completed`
+- `gecko_collector_shutdown_requested`
+- `gecko_collector_shutdown_complete`
+
+Common context:
+
+- `provider=geckoterminal`
+- `network`
+- `poolAddress`
+- `symbol`
+- `timeframe`
+- `attempt`
+- `statusCode`
+- `errorCode` or `errorMessage`
+
+## Package Scripts
+
+Add scripts:
+
+```json
+{
+  "start": "node --env-file-if-exists=.env dist/src/server.js",
+  "dev:gecko": "tsx watch src/workers/geckoCollector.ts",
+  "start:gecko": "node --env-file-if-exists=.env dist/src/workers/geckoCollector.js"
+}
+```
+
+`start:gecko` must point to `dist/src/workers/geckoCollector.js` because the
+repo builds under `dist/src/...`.
+
+The existing `build` script should continue to compile the worker through
+`tsconfig.build.json`. No bundler or runtime dependency is added.
+
+## Deployment Docs
+
+Do not modify `railway.toml` to start the collector. The collector runs as a
+second Railway service from the same repo with a service-specific start command
+override.
+
+Document two Railway services:
+
+| Service                         | Build        | Start              |
+| ------------------------------- | ------------ | ------------------ |
+| `regime-engine-web`             | `pnpm build` | `pnpm start`       |
+| `regime-engine-gecko-collector` | `pnpm build` | `pnpm start:gecko` |
+
+The web service must continue to use `pnpm start`. The collector service uses
+the same build command but overrides only the start command.
+
+Docs to update during implementation:
+
+- `README.md`: add a GeckoTerminal collector section, local commands, env table,
+  and two-service Railway notes.
+- `docs/runbooks/railway-deploy.md`: add second-service instructions and
+  verification notes.
+- `.env.example`: add worker env vars using placeholders only.
+
+`.env.example` should use:
+
+```text
+GECKO_POOL_ADDRESS=<confirm-before-production>
+```
+
+unless the canonical GeckoTerminal SOL/USDC pool has already been selected.
+
+Docs must include a deployment checkbox to confirm the canonical SOL/USDC
+GeckoTerminal pool address before production deployment.
+
+## Tests
+
+All HTTP tests use mocked `fetch`. Tests must not call GeckoTerminal.
+
+Config parser:
+
+- required env validation
+- defaults
+- invalid absolute URL
+- missing token
+- missing pool address
+- invalid positive integers
+- wrong network/timeframe/source
+
+Gecko client:
+
+- URL construction uses `URL` and `URLSearchParams`
+- path segments are encoded
+- first provider call is immediate
+- provider calls after the first are spaced by `60000 / maxCallsPerMinute`
+- retries are rate limited
+- request timeout
+- 429/5xx converted to retryable `HttpError`
+- non-429 4xx converted to non-retryable `HttpError`
+- invalid 2xx JSON is `ProtocolError`
+
+Normalizer:
+
+- Unix seconds to Unix milliseconds
+- 1h timestamp alignment
+- malformed rows dropped
+- invalid OHLCV rows dropped
+- exact duplicate kept once and excluded from corruption guard
+- conflicting duplicate timestamp drops all rows for that timestamp
+- `corruptionDroppedCount / providerRowCount > 0.10` blocks POST
+- division by zero is guarded
+- `config.geckoLookback >= 50 && validCount < 50` blocks POST
+- final candles sorted by `unixMs ASC`
+
+Ingest client:
+
+- payload shape matches `CandleIngestRequest`
+- `X-Candles-Ingest-Token` header is set
+- URL uses `/v1/candles` relative to `REGIME_ENGINE_URL`
+- 429/5xx retry
+- non-429 4xx no retry
+- 200 with `rejectedCount > 0` warns and succeeds without retry
+- invalid response JSON is `ProtocolError`
+
+Retry helper:
+
+- max 3 attempts
+- `initialBackoffMs * 2 ** (attempt - 1)`
+- max backoff cap
+- bounded injectable jitter
+- retryable vs non-retryable error behavior
+
+Collector loop:
+
+- first cycle runs immediately
+- sleeps after cycle completes
+- runtime cycle failure logs then sleeps
+- startup config failure is fatal
+- shutdown during sleep exits
+- shutdown after fetch skips ingest
+- shutdown during ingest lets request finish or timeout
+- no overlapping cycles
+
+Package/docs:
+
+- `start:gecko` points to `dist/src/workers/geckoCollector.js`
+- `start` points to `dist/src/server.js`
+- README/runbook document two Railway services
+- `.env.example` uses placeholders, including
+  `GECKO_POOL_ADDRESS=<confirm-before-production>`
+
+## Acceptance Mapping
+
+This design satisfies issue #18 by adding only the external GeckoTerminal
+collector worker, package scripts, tests, and deployment docs. It does not
+reimplement candle ingestion, candle storage, closed-candle selection,
+freshness checks, classification, or CLMM suitability. Those remain owned by
+the existing `regime-engine` HTTP and engine paths.

--- a/docs/superpowers/specs/2026-05-01-gecko-terminal-collector-design.md
+++ b/docs/superpowers/specs/2026-05-01-gecko-terminal-collector-design.md
@@ -112,8 +112,10 @@ if (isMainModule(import.meta.url, process.argv[1])) {
 }
 ```
 
-`isMainModule` can compare `import.meta.url` with `pathToFileURL(process.argv[1]).href`.
-Tests import `runOneCycle` and `runCollector` without starting the worker.
+`isMainModule` must compare real paths, not raw launch strings. Convert
+`import.meta.url` with `fileURLToPath`, resolve both paths with `realpathSync`,
+and compare those values. Tests import `runOneCycle` and `runCollector` without
+starting the worker.
 
 ### `src/workers/gecko/config.ts`
 
@@ -146,11 +148,11 @@ export function parseGeckoCollectorConfig(env?: NodeJS.ProcessEnv): GeckoCollect
 
 Hard-required env:
 
-| Variable               | Rule                             |
-| ---------------------- | -------------------------------- |
-| `REGIME_ENGINE_URL`    | absolute URL                     |
-| `CANDLES_INGEST_TOKEN` | non-empty                        |
-| `GECKO_POOL_ADDRESS`   | explicit non-empty; do not infer |
+| Variable               | Rule                                                         |
+| ---------------------- | ------------------------------------------------------------ |
+| `REGIME_ENGINE_URL`    | absolute URL; HTTPS unless localhost or Railway private host |
+| `CANDLES_INGEST_TOKEN` | non-empty                                                    |
+| `GECKO_POOL_ADDRESS`   | explicit non-empty; do not infer                             |
 
 Defaulted env, validated if present:
 
@@ -173,6 +175,7 @@ Responsibilities:
 - apply the provider-scoped rate limiter before each provider call
 - fetch with a per-request timeout controller
 - convert non-OK HTTP responses into typed `HttpError`s
+- cap response bodies before parsing JSON or error text
 - parse and return JSON as `unknown`
 
 Exports:
@@ -197,6 +200,9 @@ For MVP, `GECKO_TIMEFRAME=1h` maps to Gecko `hour` with `aggregate=1`.
 The request sends `Accept: application/json`. GeckoTerminal public API access
 does not require provider authentication for this MVP path.
 
+Response bodies are capped at 512 KiB before parsing. A larger body is a
+`ProtocolError`.
+
 ### `src/workers/gecko/normalize.ts`
 
 Responsibilities:
@@ -205,6 +211,7 @@ Responsibilities:
 - accept only the documented OHLCV list shape
 - convert Unix seconds to Unix milliseconds
 - validate rows independently
+- reject provider payloads with more than 1000 OHLCV rows
 - handle duplicate timestamps
 - sort final candles by `unixMs ASC`
 - produce structured stats and corruption-guard decisions
@@ -250,6 +257,7 @@ Responsibilities:
 - send `X-Candles-Ingest-Token`
 - fetch with a per-request timeout controller
 - convert non-OK HTTP responses into typed `HttpError`s
+- cap response bodies before parsing JSON or error text
 - validate the expected ingest response shape
 - treat `200` with `rejectedCount > 0` as success with warning, not retry
 
@@ -275,6 +283,11 @@ The `/v1/candles` response is validated strictly before logging success:
 - `rejections` is an array
 - every rejection has integer `unixMs`, reason `"STALE_REVISION"`, and string
   `existingSourceRecordedAtIso`
+
+Response bodies are capped at 512 KiB before parsing. Ingest HTTP errors should
+not retain the response body in logs or thrown error context because the upstream
+could reflect request metadata. Status code and retryability are enough for
+ingest failures.
 
 ### `src/workers/gecko/retry.ts`
 
@@ -304,13 +317,15 @@ export class HttpError extends Error {
 
 export class ProtocolError extends Error {}
 export class RequestTimeoutError extends Error {}
+export class RequestTransportError extends Error {}
 
 export type RetryOptions = {
   maxAttempts: number;
   initialBackoffMs: number;
   maxBackoffMs: number;
   jitterMs: (attempt: number) => number;
-  sleep: typeof import("node:timers/promises").setTimeout;
+  sleep: (ms: number, options?: { signal?: AbortSignal }) => Promise<unknown>;
+  signal?: AbortSignal;
   shouldContinue?: () => boolean;
 };
 
@@ -398,7 +413,9 @@ hit their own request timeout.
 
 Fetch and ingest clients create their own per-request timeout controllers. If
 shutdown is requested during a retry backoff, the collector should not start the
-next provider or ingest attempt.
+next provider or ingest attempt. Retry backoff sleeps receive the shutdown
+signal so a SIGTERM during backoff exits promptly instead of waiting for the
+full capped backoff.
 
 ## Retry, Rate Limit, And HTTP Errors
 
@@ -425,7 +442,8 @@ Retry policy for Gecko fetch and ingest POST:
   and fails the cycle.
 - timeout aborts become `RequestTimeoutError` and are retryable until attempts
   are exhausted.
-- network or transport failures are retryable until attempts are exhausted.
+- network or transport failures are wrapped as `RequestTransportError` and are
+  retryable until attempts are exhausted.
 - protocol and programmer errors are non-retryable unless explicitly classified
   as retryable.
 
@@ -485,14 +503,16 @@ Per-row validation:
 - each row must have length exactly `6`; missing fields or extra fields are
   malformed
 - `timestampSeconds` is an integer
+- `timestampSeconds` and normalized `unixMs` must be safe integers
 - `unixMs` is an integer aligned to the 1h boundary
 - `open`, `high`, `low`, and `close` are finite and `> 0`
 - `volume` is finite and `>= 0`
 - `high >= max(open, close, low)`
 - `low <= min(open, close, high)`
 
-Malformed top-level provider envelopes, missing OHLCV lists, and non-array
-OHLCV lists are protocol failures. They fail the cycle and do not POST.
+Malformed top-level provider envelopes, missing OHLCV lists, non-array OHLCV
+lists, and OHLCV lists longer than 1000 rows are protocol failures. They fail
+the cycle and do not POST.
 
 Parseable rows are validated independently:
 
@@ -547,7 +567,8 @@ if (config.geckoLookback >= 50 && validCount < 50) {
 
 The worker posts the valid subset only when the guard passes.
 When the guard does not pass, it logs and returns from `runOneCycle`; the
-collector process stays alive and the outer loop sleeps normally.
+collector process stays alive and the outer loop sleeps normally. Guard logs
+include `guardReason`: `zero_valid`, `corruption_rate`, or `low_valid_count`.
 
 ## Ingest POST
 
@@ -604,6 +625,7 @@ Use compact structured console output or an injected logger type. Events:
 - `gecko_cycle_completed`
 - `gecko_collector_shutdown_requested`
 - `gecko_collector_shutdown_complete`
+- `gecko_collector_fatal`
 
 Common context:
 
@@ -614,15 +636,22 @@ Common context:
 - `timeframe`
 - `attempt`
 - `statusCode`
-- `errorCode` or `errorMessage`
+- `errorName`, `statusCode`, or `retryable`
 
 Secret redaction rule:
 
 - never log `CANDLES_INGEST_TOKEN`
 - never log request headers containing `X-Candles-Ingest-Token`
 - never log unredacted full config objects
+- recursively redact nested keys containing `token`, `secret`, `authorization`,
+  or `headers`
+- sanitize error context before logging; do not log response bodies from ingest
+  errors
 - if config context is needed, log only non-secret fields such as provider,
   network, pool address, symbol, timeframe, lookback, poll interval, and timeout
+
+This redaction helper is still part of the minimal logger. It does not add
+metrics, tracing, sinks, log shipping, or a generic observability layer.
 
 ## Package Scripts
 
@@ -676,6 +705,9 @@ unless the canonical GeckoTerminal SOL/USDC pool has already been selected.
 
 Docs must include a deployment checkbox to confirm the canonical SOL/USDC
 GeckoTerminal pool address before production deployment.
+Docs also include a pool preflight command, a note that `new URL("/v1/candles",
+REGIME_ENGINE_URL)` targets the origin root rather than preserving any path
+prefix, and token rotation steps for `CANDLES_INGEST_TOKEN`.
 
 ## Tests
 
@@ -686,6 +718,9 @@ Config parser:
 - required env validation
 - defaults
 - invalid absolute URL
+- rejects plain HTTP except `localhost`, `127.0.0.1`, `::1`, and
+  `*.railway.internal`
+- rejects explicit empty optional env vars instead of silently defaulting
 - missing token
 - missing pool address
 - invalid positive integers
@@ -703,7 +738,7 @@ Gecko client:
 - injectable `now?: () => number` makes limiter tests deterministic
 - request timeout
 - timeout aborts become `RequestTimeoutError`
-- network/transport failures are retryable
+- network/transport failures become retryable `RequestTransportError`
 - protocol/programmer errors are non-retryable unless explicitly classified
 - 429/5xx converted to retryable `HttpError`
 - non-429 4xx converted to non-retryable `HttpError`
@@ -715,6 +750,8 @@ Normalizer:
 - 1h timestamp alignment
 - non-array rows are malformed
 - rows with `length !== 6` are malformed, including missing or extra fields
+- timestamps must be safe integers
+- payloads with more than 1000 OHLCV rows fail before iteration
 - malformed rows dropped
 - invalid OHLCV rows dropped
 - exact duplicate kept once and excluded from corruption guard
@@ -754,6 +791,7 @@ Collector loop:
 - shutdown during sleep exits
 - shutdown after fetch skips ingest
 - shutdown during ingest lets request finish or timeout
+- shutdown during retry backoff exits promptly
 - no overlapping cycles
 - ESM entrypoint guard prevents imports from starting the loop
 

--- a/docs/superpowers/specs/2026-05-01-gecko-terminal-collector-design.md
+++ b/docs/superpowers/specs/2026-05-01-gecko-terminal-collector-design.md
@@ -80,11 +80,15 @@ Allowed shared imports are limited to contract types/constants such as
 Responsibilities:
 
 - parse config by calling `parseGeckoCollectorConfig(process.env)`
+- use an ESM entrypoint guard so importing this module in tests does not start
+  the collector loop
 - install `SIGTERM` and `SIGINT` handlers
 - run one cycle immediately on startup
 - sleep after each completed or failed cycle
 - prevent overlapping cycles by using a sequential async loop
 - check shutdown state between phases
+- create the GeckoTerminal provider rate limiter once per collector process and
+  reuse it across cycles and retry attempts
 
 Exports:
 
@@ -99,6 +103,17 @@ export function runCollector(
 
 `GeckoCollectorDeps` is only a test seam for logger, sleep, now, fetch/random
 indirection where needed. It is not a framework.
+
+Entrypoint guard:
+
+```ts
+if (isMainModule(import.meta.url, process.argv[1])) {
+  void runCollector();
+}
+```
+
+`isMainModule` can compare `import.meta.url` with `pathToFileURL(process.argv[1]).href`.
+Tests import `runOneCycle` and `runCollector` without starting the worker.
 
 ### `src/workers/gecko/config.ts`
 
@@ -118,7 +133,7 @@ export type GeckoCollectorConfig = {
   geckoSource: "geckoterminal";
   geckoNetwork: "solana";
   geckoPoolAddress: string;
-  geckoSymbol: string;
+  geckoSymbol: "SOL/USDC";
   geckoTimeframe: "1h";
   geckoLookback: number;
   geckoPollIntervalMs: number;
@@ -143,7 +158,7 @@ Defaulted env, validated if present:
 | ---------------------------- | --------------- | -------------------------- |
 | `GECKO_SOURCE`               | `geckoterminal` | must equal `geckoterminal` |
 | `GECKO_NETWORK`              | `solana`        | must equal `solana`        |
-| `GECKO_SYMBOL`               | `SOL/USDC`      | non-empty                  |
+| `GECKO_SYMBOL`               | `SOL/USDC`      | must equal `SOL/USDC`      |
 | `GECKO_TIMEFRAME`            | `1h`            | must equal `1h`            |
 | `GECKO_LOOKBACK`             | `200`           | positive integer           |
 | `GECKO_POLL_INTERVAL_MS`     | `300000`        | positive integer           |
@@ -252,6 +267,15 @@ export function postCandles(
 `sourceRecordedAtIso` is set once per successfully fetched batch and reused
 across ingest retries.
 
+The `/v1/candles` response is validated strictly before logging success:
+
+- `schemaVersion === "1.0"`
+- `insertedCount`, `revisedCount`, `idempotentCount`, and `rejectedCount` are
+  non-negative integers
+- `rejections` is an array
+- every rejection has integer `unixMs`, reason `"STALE_REVISION"`, and string
+  `existingSourceRecordedAtIso`
+
 ### `src/workers/gecko/retry.ts`
 
 Responsibilities:
@@ -264,10 +288,18 @@ Responsibilities:
 Exports:
 
 ```ts
+export type HttpErrorOptions = {
+  statusCode: number;
+  responseBody?: string;
+  retryable?: boolean;
+  message?: string;
+};
+
 export class HttpError extends Error {
   statusCode: number;
   responseBody?: string;
   retryable: boolean;
+  constructor(options: HttpErrorOptions);
 }
 
 export class ProtocolError extends Error {}
@@ -289,7 +321,10 @@ export function withRetry<T>(
 
 export function createRateLimiter(
   maxCallsPerMinute: number,
-  sleep?: typeof import("node:timers/promises").setTimeout
+  deps?: {
+    sleep?: typeof import("node:timers/promises").setTimeout;
+    now?: () => number;
+  }
 ): () => Promise<void>;
 
 export function isRetryableHttpStatus(status: number): boolean;
@@ -297,6 +332,11 @@ export function isRetryableHttpStatus(status: number): boolean;
 
 `createRateLimiter` is only for GeckoTerminal provider calls. It is not applied
 to `/v1/candles` ingest POSTs.
+
+The rate limiter is constructed once in `runCollector` and injected into cycle
+dependencies. It must not be recreated inside each `fetchGeckoOhlcv` call,
+because that would reset spacing across cycles and retries. `now?: () => number`
+is injectable for deterministic rate-limiter tests.
 
 ### `src/workers/gecko/logger.ts`
 
@@ -339,6 +379,10 @@ interval before proving env, provider access, normalization, ingest auth, and
 9. Log ingest counts and cycle completion.
 ```
 
+If the zero-valid or corruption guard blocks a batch, `runOneCycle` logs a
+controlled skipped-ingest cycle and returns. This is not a process crash. The
+outer loop then sleeps normally.
+
 Shutdown rules:
 
 - SIGTERM/SIGINT during sleep: abort sleep and exit.
@@ -379,8 +423,29 @@ Retry policy for Gecko fetch and ingest POST:
 - non-429 `4xx` becomes non-retryable `HttpError`.
 - `2xx` with invalid JSON or unexpected response shape becomes `ProtocolError`
   and fails the cycle.
-- network errors and request timeouts are retryable until attempts are
-  exhausted.
+- timeout aborts become `RequestTimeoutError` and are retryable until attempts
+  are exhausted.
+- network or transport failures are retryable until attempts are exhausted.
+- protocol and programmer errors are non-retryable unless explicitly classified
+  as retryable.
+
+`HttpError` constructor shape:
+
+```ts
+type HttpErrorOptions = {
+  statusCode: number;
+  responseBody?: string;
+  retryable?: boolean;
+  message?: string;
+};
+
+new HttpError({
+  statusCode,
+  responseBody,
+  retryable: isRetryableHttpStatus(statusCode),
+  message: `HTTP ${statusCode}`
+});
+```
 
 Provider rate limiting:
 
@@ -388,6 +453,7 @@ Provider rate limiting:
 - first provider call is immediate
 - retries are also provider calls and are rate limited
 - one provider request is in flight at a time
+- one limiter is created per collector process and reused across cycles/retries
 - subsequent provider calls are spaced by at least
   `60000 / GECKO_MAX_CALLS_PER_MINUTE` milliseconds
 - default `GECKO_MAX_CALLS_PER_MINUTE=6`, so at most one provider call every
@@ -415,6 +481,9 @@ unixMs = timestampSeconds * 1000
 
 Per-row validation:
 
+- each row must be an array
+- each row must have length exactly `6`; missing fields or extra fields are
+  malformed
 - `timestampSeconds` is an integer
 - `unixMs` is an integer aligned to the 1h boundary
 - `open`, `high`, `low`, and `close` are finite and `> 0`
@@ -427,7 +496,8 @@ OHLCV lists are protocol failures. They fail the cycle and do not POST.
 
 Parseable rows are validated independently:
 
-- malformed, misaligned, or invalid-OHLCV rows are dropped locally
+- non-array rows, rows with `length !== 6`, rows with missing fields, rows with
+  extra fields, misaligned rows, or invalid-OHLCV rows are dropped locally
 - exact duplicate rows are deduped
 - conflicting duplicate timestamps drop all rows for that timestamp
 - final valid candles are sorted by `unixMs ASC`
@@ -476,6 +546,8 @@ if (config.geckoLookback >= 50 && validCount < 50) {
 ```
 
 The worker posts the valid subset only when the guard passes.
+When the guard does not pass, it logs and returns from `runOneCycle`; the
+collector process stays alive and the outer loop sleeps normally.
 
 ## Ingest POST
 
@@ -544,6 +616,14 @@ Common context:
 - `statusCode`
 - `errorCode` or `errorMessage`
 
+Secret redaction rule:
+
+- never log `CANDLES_INGEST_TOKEN`
+- never log request headers containing `X-Candles-Ingest-Token`
+- never log unredacted full config objects
+- if config context is needed, log only non-secret fields such as provider,
+  network, pool address, symbol, timeframe, lookback, poll interval, and timeout
+
 ## Package Scripts
 
 Add scripts:
@@ -610,15 +690,21 @@ Config parser:
 - missing pool address
 - invalid positive integers
 - wrong network/timeframe/source
+- `GECKO_SYMBOL` defaults to `SOL/USDC` and rejects any other value
 
 Gecko client:
 
 - URL construction uses `URL` and `URLSearchParams`
 - path segments are encoded
 - first provider call is immediate
+- provider rate limiter is created once per collector process, not per fetch
 - provider calls after the first are spaced by `60000 / maxCallsPerMinute`
 - retries are rate limited
+- injectable `now?: () => number` makes limiter tests deterministic
 - request timeout
+- timeout aborts become `RequestTimeoutError`
+- network/transport failures are retryable
+- protocol/programmer errors are non-retryable unless explicitly classified
 - 429/5xx converted to retryable `HttpError`
 - non-429 4xx converted to non-retryable `HttpError`
 - invalid 2xx JSON is `ProtocolError`
@@ -627,6 +713,8 @@ Normalizer:
 
 - Unix seconds to Unix milliseconds
 - 1h timestamp alignment
+- non-array rows are malformed
+- rows with `length !== 6` are malformed, including missing or extra fields
 - malformed rows dropped
 - invalid OHLCV rows dropped
 - exact duplicate kept once and excluded from corruption guard
@@ -640,10 +728,13 @@ Ingest client:
 
 - payload shape matches `CandleIngestRequest`
 - `X-Candles-Ingest-Token` header is set
+- token and token-bearing request headers are never logged
 - URL uses `/v1/candles` relative to `REGIME_ENGINE_URL`
 - 429/5xx retry
 - non-429 4xx no retry
 - 200 with `rejectedCount > 0` warns and succeeds without retry
+- response validates `schemaVersion === "1.0"` and all count fields as
+  non-negative integers
 - invalid response JSON is `ProtocolError`
 
 Retry helper:
@@ -664,6 +755,7 @@ Collector loop:
 - shutdown after fetch skips ingest
 - shutdown during ingest lets request finish or timeout
 - no overlapping cycles
+- ESM entrypoint guard prevents imports from starting the loop
 
 Package/docs:
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "db:migrate": "drizzle-kit migrate",
     "db:generate": "drizzle-kit generate",
     "db:push": "drizzle-kit push",
+    "start": "node --env-file-if-exists=.env dist/src/server.js",
+    "dev:gecko": "tsx watch src/workers/geckoCollector.ts",
+    "start:gecko": "node --env-file-if-exists=.env dist/src/workers/geckoCollector.js",
     "prepare": "husky || true"
   },
   "dependencies": {

--- a/src/workers/__tests__/geckoCollector.test.ts
+++ b/src/workers/__tests__/geckoCollector.test.ts
@@ -236,6 +236,32 @@ describe("runCollector", () => {
     const listenersAfter = process.listenerCount("SIGTERM");
     expect(listenersAfter).toBe(listenersBefore);
   });
+
+  it("rethrows cycle error so exit code is non-zero", async () => {
+    const shutdownController = new AbortController();
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    } as unknown as WorkerLogger;
+
+    const cycleError = new Error("boom");
+    const runOneCycleFn = vi.fn(async () => {
+      throw cycleError;
+    });
+
+    const sleep = vi.fn(async () => {});
+
+    const loopDeps: CollectorLoopDeps = {
+      signal: shutdownController.signal,
+      logger: logger as WorkerLogger,
+      runOneCycleFn,
+      sleep
+    };
+
+    const { runCollector } = await import("../geckoCollector.js");
+    await expect(runCollector(BASE_CONFIG, loopDeps)).rejects.toThrow("boom");
+  });
 });
 
 describe("package scripts", () => {

--- a/src/workers/__tests__/geckoCollector.test.ts
+++ b/src/workers/__tests__/geckoCollector.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi } from "vitest";
+import { isMainModule, runOneCycle } from "../geckoCollector.js";
+import type { GeckoCollectorDeps } from "../geckoCollector.js";
+import type { GeckoCollectorConfig } from "../gecko/config.js";
+import type { WorkerLogger } from "../gecko/logger.js";
+import type { CandleIngestResponse } from "../../contract/v1/types.js";
+import { SCHEMA_VERSION } from "../../contract/v1/types.js";
+import { readFileSync } from "node:fs";
+
+const BASE_CONFIG: GeckoCollectorConfig = {
+  regimeEngineUrl: new URL("https://regime-engine.example"),
+  candlesIngestToken: "tok_abc123",
+  geckoSource: "geckoterminal",
+  geckoNetwork: "solana",
+  geckoPoolAddress: "pool123",
+  geckoSymbol: "SOL/USDC",
+  geckoTimeframe: "1h",
+  geckoLookback: 10,
+  geckoPollIntervalMs: 300000,
+  geckoMaxCallsPerMinute: 6,
+  geckoRequestTimeoutMs: 10000
+};
+
+const VALID_PAYLOAD = {
+  data: {
+    attributes: {
+      ohlcv_list: [[1714536000, 100, 105, 98, 102, 1000]]
+    }
+  }
+};
+
+const VALID_INGEST_RESPONSE: CandleIngestResponse = {
+  schemaVersion: SCHEMA_VERSION,
+  insertedCount: 1,
+  revisedCount: 0,
+  idempotentCount: 0,
+  rejectedCount: 0,
+  rejections: []
+};
+
+describe("isMainModule", () => {
+  it("returns false for different paths", () => {
+    expect(isMainModule("file:///a/b/c.ts", "/x/y/z.ts")).toBe(false);
+  });
+
+  it("returns true for same real file", () => {
+    expect(isMainModule(import.meta.url, process.argv[1])).toBe(
+      import.meta.url === `file://${process.argv[1]}`
+    );
+  });
+});
+
+describe("runOneCycle", () => {
+  it("fetches, normalizes and posts candles with logging", async () => {
+    const logs: { level: string; event: string }[] = [];
+    const logger = {
+      info: (event: string) => logs.push({ level: "info", event }),
+      warn: () => {},
+      error: () => {}
+    };
+
+    const deps: GeckoCollectorDeps = {
+      fetchGeckoOhlcv: vi.fn(async () => VALID_PAYLOAD),
+      postCandles: vi.fn(async () => VALID_INGEST_RESPONSE),
+      logger: logger as WorkerLogger,
+      nowIso: () => "2026-05-01T00:00:00.000Z"
+    };
+
+    await runOneCycle(BASE_CONFIG, deps);
+
+    expect(deps.fetchGeckoOhlcv).toHaveBeenCalledTimes(1);
+    expect(deps.postCandles).toHaveBeenCalledTimes(1);
+    expect(logs.map((l) => l.event)).toEqual([
+      "cycle_started",
+      "fetch_succeeded",
+      "normalized",
+      "ingest_succeeded",
+      "cycle_completed"
+    ]);
+  });
+
+  it("skips ingest after shutdown during fetch phase", async () => {
+    let shouldContinue = true;
+    const logger = {
+      info: () => {},
+      warn: () => {},
+      error: () => {}
+    };
+
+    const deps: GeckoCollectorDeps = {
+      fetchGeckoOhlcv: vi.fn(async () => {
+        shouldContinue = false;
+        return VALID_PAYLOAD;
+      }),
+      postCandles: vi.fn(async () => VALID_INGEST_RESPONSE),
+      logger: logger as WorkerLogger,
+      nowIso: () => "2026-05-01T00:00:00.000Z",
+      shouldContinue: () => shouldContinue
+    };
+
+    await runOneCycle(BASE_CONFIG, deps);
+
+    expect(deps.fetchGeckoOhlcv).toHaveBeenCalledTimes(1);
+    expect(deps.postCandles).toHaveBeenCalledTimes(0);
+  });
+
+  it("blocks on zero valid with warning", async () => {
+    const warns: { event: string; reason?: string }[] = [];
+    const logger = {
+      info: () => {},
+      warn: (event: string, ctx?: Record<string, unknown>) =>
+        warns.push({ event, reason: ctx?.reason as string | undefined }),
+      error: () => {}
+    };
+
+    const emptyPayload = { data: { attributes: { ohlcv_list: [] } } };
+
+    const deps: GeckoCollectorDeps = {
+      fetchGeckoOhlcv: vi.fn(async () => emptyPayload),
+      postCandles: vi.fn(async () => VALID_INGEST_RESPONSE),
+      logger: logger as WorkerLogger,
+      nowIso: () => "2026-05-01T00:00:00.000Z"
+    };
+
+    await runOneCycle(BASE_CONFIG, deps);
+
+    expect(deps.postCandles).toHaveBeenCalledTimes(0);
+    expect(warns).toHaveLength(1);
+    expect(warns[0].reason).toBe("zero_valid");
+  });
+
+  it("completes in-flight ingest before shutdown check", async () => {
+    let shouldContinueFlag = true;
+    const logger = {
+      info: () => {},
+      warn: () => {},
+      error: () => {}
+    };
+
+    const deps: GeckoCollectorDeps = {
+      fetchGeckoOhlcv: vi.fn(async () => VALID_PAYLOAD),
+      postCandles: vi.fn(async () => {
+        shouldContinueFlag = false;
+        return VALID_INGEST_RESPONSE;
+      }),
+      logger: logger as WorkerLogger,
+      nowIso: () => "2026-05-01T00:00:00.000Z",
+      shouldContinue: () => shouldContinueFlag
+    };
+
+    await runOneCycle(BASE_CONFIG, deps);
+
+    expect(deps.postCandles).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs ingest failure before rethrow", async () => {
+    const errors: string[] = [];
+    const logger = {
+      info: () => {},
+      warn: () => {},
+      error: (event: string, ctx?: Record<string, unknown>) => errors.push(ctx?.error as string)
+    };
+
+    const deps: GeckoCollectorDeps = {
+      fetchGeckoOhlcv: vi.fn(async () => VALID_PAYLOAD),
+      postCandles: vi.fn(async () => {
+        throw new Error("server down");
+      }),
+      logger: logger as WorkerLogger,
+      nowIso: () => "2026-05-01T00:00:00.000Z"
+    };
+
+    await expect(runOneCycle(BASE_CONFIG, deps)).rejects.toThrow("server down");
+    expect(errors).toContain("server down");
+  });
+});
+
+describe("package scripts", () => {
+  it("points start scripts at dist/src outputs", () => {
+    const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
+      scripts: Record<string, string>;
+    };
+
+    expect(packageJson.scripts.start).toContain("dist/src/server.js");
+    expect(packageJson.scripts["dev:gecko"]).toContain("src/workers/geckoCollector.ts");
+    expect(packageJson.scripts["start:gecko"]).toContain("dist/src/workers/geckoCollector.js");
+  });
+});

--- a/src/workers/__tests__/geckoCollector.test.ts
+++ b/src/workers/__tests__/geckoCollector.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { isMainModule, runOneCycle } from "../geckoCollector.js";
-import type { GeckoCollectorDeps } from "../geckoCollector.js";
+import type { CollectorLoopDeps, GeckoCollectorDeps } from "../geckoCollector.js";
 import type { GeckoCollectorConfig } from "../gecko/config.js";
 import type { WorkerLogger } from "../gecko/logger.js";
 import type { CandleIngestResponse } from "../../contract/v1/types.js";
@@ -172,6 +172,69 @@ describe("runOneCycle", () => {
 
     await expect(runOneCycle(BASE_CONFIG, deps)).rejects.toThrow("server down");
     expect(errors).toContain("server down");
+  });
+});
+
+describe("runCollector", () => {
+  it("runs two cycles then shuts down", async () => {
+    const shutdownController = new AbortController();
+    let cycleCount = 0;
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    } as unknown as WorkerLogger;
+
+    const runOneCycleFn = vi.fn(async () => {
+      cycleCount++;
+      if (cycleCount >= 2) {
+        shutdownController.abort();
+      }
+    });
+
+    const sleep = vi.fn(async () => {});
+
+    const loopDeps: CollectorLoopDeps = {
+      signal: shutdownController.signal,
+      logger: logger as WorkerLogger,
+      runOneCycleFn,
+      sleep
+    };
+
+    const { runCollector } = await import("../geckoCollector.js");
+    await runCollector(BASE_CONFIG, loopDeps);
+
+    expect(cycleCount).toBeGreaterThanOrEqual(2);
+    expect(logger.info).toHaveBeenCalledWith("shutdown_complete");
+  });
+
+  it("removes signal handlers on shutdown", async () => {
+    const listenersBefore = process.listenerCount("SIGTERM");
+    const shutdownController = new AbortController();
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    } as unknown as WorkerLogger;
+
+    const runOneCycleFn = vi.fn(async () => {
+      shutdownController.abort();
+    });
+
+    const sleep = vi.fn(async () => {});
+
+    const loopDeps: CollectorLoopDeps = {
+      signal: shutdownController.signal,
+      logger: logger as WorkerLogger,
+      runOneCycleFn,
+      sleep
+    };
+
+    const { runCollector } = await import("../geckoCollector.js");
+    await runCollector(BASE_CONFIG, loopDeps);
+
+    const listenersAfter = process.listenerCount("SIGTERM");
+    expect(listenersAfter).toBe(listenersBefore);
   });
 });
 

--- a/src/workers/__tests__/geckoCollector.test.ts
+++ b/src/workers/__tests__/geckoCollector.test.ts
@@ -237,7 +237,7 @@ describe("runCollector", () => {
     expect(listenersAfter).toBe(listenersBefore);
   });
 
-  it("rethrows cycle error so exit code is non-zero", async () => {
+  it("continues looping after recoverable cycle error", async () => {
     const shutdownController = new AbortController();
     const logger = {
       info: vi.fn(),
@@ -245,9 +245,11 @@ describe("runCollector", () => {
       error: vi.fn()
     } as unknown as WorkerLogger;
 
-    const cycleError = new Error("boom");
+    let cycleCount = 0;
     const runOneCycleFn = vi.fn(async () => {
-      throw cycleError;
+      cycleCount++;
+      if (cycleCount === 1) throw new Error("transient");
+      if (cycleCount >= 2) shutdownController.abort();
     });
 
     const sleep = vi.fn(async () => {});
@@ -260,7 +262,10 @@ describe("runCollector", () => {
     };
 
     const { runCollector } = await import("../geckoCollector.js");
-    await expect(runCollector(BASE_CONFIG, loopDeps)).rejects.toThrow("boom");
+    await runCollector(BASE_CONFIG, loopDeps);
+
+    expect(cycleCount).toBeGreaterThanOrEqual(2);
+    expect(logger.error).toHaveBeenCalledWith("cycle_error", { error: "transient" });
   });
 });
 

--- a/src/workers/gecko/__tests__/config.test.ts
+++ b/src/workers/gecko/__tests__/config.test.ts
@@ -129,4 +129,9 @@ describe("parseGeckoCollectorConfig", () => {
     const env = { ...MINIMAL_ENV, GECKO_LOOKBACK: "1001" };
     expect(() => parseGeckoCollectorConfig(env)).toThrow("must be a positive integer ≤ 1000");
   });
+
+  it("rejects REGIME_ENGINE_URL with a path component", () => {
+    const env = { ...MINIMAL_ENV, REGIME_ENGINE_URL: "https://regime-engine.example/api" };
+    expect(() => parseGeckoCollectorConfig(env)).toThrow("must not contain a path component");
+  });
 });

--- a/src/workers/gecko/__tests__/config.test.ts
+++ b/src/workers/gecko/__tests__/config.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { parseGeckoCollectorConfig } from "../config.js";
+
+const MINIMAL_ENV: Record<string, string | undefined> = {
+  REGIME_ENGINE_URL: "https://regime-engine.example",
+  CANDLES_INGEST_TOKEN: "tok_abc123",
+  GECKO_POOL_ADDRESS: "So1enD8SdYKeb4s4XxKQsXKQsXKQsXKQsXKQsXKQsXK"
+};
+
+describe("parseGeckoCollectorConfig", () => {
+  it("returns MVP defaults for minimal env", () => {
+    const config = parseGeckoCollectorConfig(MINIMAL_ENV);
+    expect(config.regimeEngineUrl.href).toBe("https://regime-engine.example/");
+    expect(config.candlesIngestToken).toBe("tok_abc123");
+    expect(config.geckoSource).toBe("geckoterminal");
+    expect(config.geckoNetwork).toBe("solana");
+    expect(config.geckoPoolAddress).toBe("So1enD8SdYKeb4s4XxKQsXKQsXKQsXKQsXKQsXKQsXK");
+    expect(config.geckoSymbol).toBe("SOL/USDC");
+    expect(config.geckoTimeframe).toBe("1h");
+    expect(config.geckoLookback).toBe(200);
+    expect(config.geckoPollIntervalMs).toBe(300000);
+    expect(config.geckoMaxCallsPerMinute).toBe(6);
+    expect(config.geckoRequestTimeoutMs).toBe(10000);
+  });
+
+  it("uses explicit values when provided", () => {
+    const env = {
+      ...MINIMAL_ENV,
+      GECKO_SOURCE: "geckoterminal",
+      GECKO_NETWORK: "solana",
+      GECKO_SYMBOL: "SOL/USDC",
+      GECKO_TIMEFRAME: "1h",
+      GECKO_LOOKBACK: "500",
+      GECKO_POLL_INTERVAL_MS: "60000",
+      GECKO_MAX_CALLS_PER_MINUTE: "10",
+      GECKO_REQUEST_TIMEOUT_MS: "5000"
+    };
+    const config = parseGeckoCollectorConfig(env);
+    expect(config.geckoLookback).toBe(500);
+    expect(config.geckoPollIntervalMs).toBe(60000);
+    expect(config.geckoMaxCallsPerMinute).toBe(10);
+    expect(config.geckoRequestTimeoutMs).toBe(5000);
+  });
+
+  it("throws for missing REGIME_ENGINE_URL", () => {
+    const env = { ...MINIMAL_ENV, REGIME_ENGINE_URL: undefined };
+    expect(() => parseGeckoCollectorConfig(env)).toThrow("Missing required env: REGIME_ENGINE_URL");
+  });
+
+  it("throws for missing CANDLES_INGEST_TOKEN", () => {
+    const env = { ...MINIMAL_ENV, CANDLES_INGEST_TOKEN: undefined };
+    expect(() => parseGeckoCollectorConfig(env)).toThrow(
+      "Missing required env: CANDLES_INGEST_TOKEN"
+    );
+  });
+
+  it("throws for missing GECKO_POOL_ADDRESS", () => {
+    const env = { ...MINIMAL_ENV, GECKO_POOL_ADDRESS: undefined };
+    expect(() => parseGeckoCollectorConfig(env)).toThrow(
+      "Missing required env: GECKO_POOL_ADDRESS"
+    );
+  });
+
+  it("throws for placeholder pool address with angle brackets", () => {
+    const env = { ...MINIMAL_ENV, GECKO_POOL_ADDRESS: "<confirm-before-production>" };
+    expect(() => parseGeckoCollectorConfig(env)).toThrow("placeholder");
+  });
+
+  it("throws for non-absolute URL", () => {
+    const env = { ...MINIMAL_ENV, REGIME_ENGINE_URL: "not-a-url" };
+    expect(() => parseGeckoCollectorConfig(env)).toThrow("not a valid absolute URL");
+  });
+
+  it("allows HTTP for localhost", () => {
+    const env = { ...MINIMAL_ENV, REGIME_ENGINE_URL: "http://localhost:3000" };
+    const config = parseGeckoCollectorConfig(env);
+    expect(config.regimeEngineUrl.href).toBe("http://localhost:3000/");
+  });
+
+  it("allows HTTP for 127.0.0.1", () => {
+    const env = { ...MINIMAL_ENV, REGIME_ENGINE_URL: "http://127.0.0.1:3000" };
+    const config = parseGeckoCollectorConfig(env);
+    expect(config.regimeEngineUrl.href).toBe("http://127.0.0.1:3000/");
+  });
+
+  it("allows HTTP for *.railway.internal", () => {
+    const env = { ...MINIMAL_ENV, REGIME_ENGINE_URL: "http://regime.railway.internal:3000" };
+    const config = parseGeckoCollectorConfig(env);
+    expect(config.regimeEngineUrl.href).toBe("http://regime.railway.internal:3000/");
+  });
+
+  it("throws for plain HTTP to remote host", () => {
+    const env = { ...MINIMAL_ENV, REGIME_ENGINE_URL: "http://regime-engine.example" };
+    expect(() => parseGeckoCollectorConfig(env)).toThrow("must use HTTPS");
+  });
+
+  it("throws for unsupported GECKO_SOURCE", () => {
+    const env = { ...MINIMAL_ENV, GECKO_SOURCE: "other" };
+    expect(() => parseGeckoCollectorConfig(env)).toThrow("Unsupported GECKO_SOURCE");
+  });
+
+  it("throws for unsupported GECKO_NETWORK", () => {
+    const env = { ...MINIMAL_ENV, GECKO_NETWORK: "ethereum" };
+    expect(() => parseGeckoCollectorConfig(env)).toThrow("Unsupported GECKO_NETWORK");
+  });
+
+  it("throws for unsupported GECKO_SYMBOL", () => {
+    const env = { ...MINIMAL_ENV, GECKO_SYMBOL: "ETH/USDC" };
+    expect(() => parseGeckoCollectorConfig(env)).toThrow("Unsupported GECKO_SYMBOL");
+  });
+
+  it("throws for unsupported GECKO_TIMEFRAME", () => {
+    const env = { ...MINIMAL_ENV, GECKO_TIMEFRAME: "5m" };
+    expect(() => parseGeckoCollectorConfig(env)).toThrow("Unsupported GECKO_TIMEFRAME");
+  });
+
+  it("treats empty string as default for literal env", () => {
+    const env = { ...MINIMAL_ENV, GECKO_SOURCE: "" };
+    const config = parseGeckoCollectorConfig(env);
+    expect(config.geckoSource).toBe("geckoterminal");
+  });
+
+  it("throws for invalid numeric env", () => {
+    const env = { ...MINIMAL_ENV, GECKO_LOOKBACK: "abc" };
+    expect(() => parseGeckoCollectorConfig(env)).toThrow("must be a positive integer");
+  });
+
+  it("throws for lookback exceeding max", () => {
+    const env = { ...MINIMAL_ENV, GECKO_LOOKBACK: "1001" };
+    expect(() => parseGeckoCollectorConfig(env)).toThrow("must be a positive integer ≤ 1000");
+  });
+});

--- a/src/workers/gecko/__tests__/geckoClient.test.ts
+++ b/src/workers/gecko/__tests__/geckoClient.test.ts
@@ -114,4 +114,16 @@ describe("fetchGeckoOhlcv", () => {
     });
     await expect(fetchGeckoOhlcv(BASE_CONFIG, { fetch })).rejects.toThrow(RequestTransportError);
   });
+
+  it("aborts in-flight request when shutdown signal fires", async () => {
+    const controller = new AbortController();
+    const fetch = vi.fn(async (_input: string | URL | Request, opts?: RequestInit) => {
+      expect(opts?.signal?.aborted).toBe(false);
+      controller.abort();
+      throw new DOMException("The operation was aborted", "AbortError");
+    });
+    await expect(
+      fetchGeckoOhlcv(BASE_CONFIG, { fetch, shutdownSignal: controller.signal })
+    ).rejects.toThrow(RequestTimeoutError);
+  });
 });

--- a/src/workers/gecko/__tests__/geckoClient.test.ts
+++ b/src/workers/gecko/__tests__/geckoClient.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from "vitest";
+import { fetchGeckoOhlcv } from "../geckoClient.js";
+import { HttpError, ProtocolError, RequestTimeoutError, RequestTransportError } from "../retry.js";
+import type { GeckoCollectorConfig } from "../config.js";
+
+const BASE_CONFIG: GeckoCollectorConfig = {
+  regimeEngineUrl: new URL("https://regime-engine.example"),
+  candlesIngestToken: "tok_abc123",
+  geckoSource: "geckoterminal",
+  geckoNetwork: "solana",
+  geckoPoolAddress: "pool123",
+  geckoSymbol: "SOL/USDC",
+  geckoTimeframe: "1h",
+  geckoLookback: 200,
+  geckoPollIntervalMs: 300000,
+  geckoMaxCallsPerMinute: 6,
+  geckoRequestTimeoutMs: 10000
+};
+
+const VALID_RESPONSE = {
+  data: {
+    attributes: {
+      ohlcv_list: [[1714536000, 100, 105, 98, 102, 1000]]
+    }
+  }
+};
+
+function mockFetch(response: Response | (() => Promise<Response>)): typeof globalThis.fetch {
+  if (typeof response === "function") {
+    return vi.fn(response);
+  }
+  return vi.fn(async () => response);
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  const text = JSON.stringify(body);
+  return new Response(text, {
+    status,
+    headers: { "content-type": "application/json", "content-length": String(text.length) }
+  });
+}
+
+describe("fetchGeckoOhlcv", () => {
+  it("builds encoded URL with network and poolAddress", async () => {
+    const config = { ...BASE_CONFIG, geckoNetwork: "solana", geckoPoolAddress: "pool with spaces" };
+    const fetch = mockFetch(jsonResponse(VALID_RESPONSE));
+    await fetchGeckoOhlcv(config, { fetch });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toContain("solana");
+    expect(calledUrl).toContain("pool%20with%20spaces");
+  });
+
+  it("sends Accept header", async () => {
+    const fetch = mockFetch(jsonResponse(VALID_RESPONSE));
+    await fetchGeckoOhlcv(BASE_CONFIG, { fetch });
+    const opts = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+    expect(opts.headers).toEqual({ Accept: "application/json" });
+  });
+
+  it("returns 429 as retryable HttpError", async () => {
+    const fetch = mockFetch(new Response("rate limited", { status: 429 }));
+    await expect(fetchGeckoOhlcv(BASE_CONFIG, { fetch })).rejects.toThrow(HttpError);
+    const err = (await fetchGeckoOhlcv(BASE_CONFIG, { fetch }).catch(
+      (e: unknown) => e
+    )) as HttpError;
+    expect(err.retryable).toBe(true);
+  });
+
+  it("returns 503 as retryable HttpError", async () => {
+    const fetch = mockFetch(new Response("unavailable", { status: 503 }));
+    await expect(fetchGeckoOhlcv(BASE_CONFIG, { fetch })).rejects.toThrow(HttpError);
+  });
+
+  it("returns 404 as non-retryable HttpError", async () => {
+    const fetch = mockFetch(new Response("not found", { status: 404 }));
+    await expect(fetchGeckoOhlcv(BASE_CONFIG, { fetch })).rejects.toThrow(HttpError);
+    const err = (await fetchGeckoOhlcv(BASE_CONFIG, { fetch }).catch(
+      (e: unknown) => e
+    )) as HttpError;
+    expect(err.retryable).toBe(false);
+  });
+
+  it("throws ProtocolError for invalid JSON", async () => {
+    const fetch = mockFetch(
+      new Response("not json", {
+        status: 200,
+        headers: { "content-type": "text/plain", "content-length": "8" }
+      })
+    );
+    await expect(fetchGeckoOhlcv(BASE_CONFIG, { fetch })).rejects.toThrow(ProtocolError);
+  });
+
+  it("throws ProtocolError for oversized body via content-length", async () => {
+    const fetch = mockFetch(
+      new Response("", {
+        status: 200,
+        headers: { "content-type": "application/json", "content-length": "600000" }
+      })
+    );
+    await expect(fetchGeckoOhlcv(BASE_CONFIG, { fetch })).rejects.toThrow(ProtocolError);
+  });
+
+  it("throws RequestTimeoutError on timeout", async () => {
+    const fetch = vi.fn(async () => {
+      throw new DOMException("The operation was aborted", "TimeoutError");
+    });
+    await expect(fetchGeckoOhlcv(BASE_CONFIG, { fetch })).rejects.toThrow(RequestTimeoutError);
+  });
+
+  it("throws RequestTransportError on TypeError", async () => {
+    const fetch = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    });
+    await expect(fetchGeckoOhlcv(BASE_CONFIG, { fetch })).rejects.toThrow(RequestTransportError);
+  });
+});

--- a/src/workers/gecko/__tests__/ingestClient.test.ts
+++ b/src/workers/gecko/__tests__/ingestClient.test.ts
@@ -120,6 +120,24 @@ describe("postCandles", () => {
     ).rejects.toThrow(ProtocolError);
   });
 
+  it("throws ProtocolError for unexpected rejection reason", async () => {
+    const response = {
+      ...VALID_RESPONSE,
+      rejectedCount: 1,
+      rejections: [
+        {
+          unixMs: 1714536000000,
+          reason: "UNKNOWN",
+          existingSourceRecordedAtIso: "2026-05-01T00:00:00Z"
+        }
+      ]
+    };
+    const fetch = mockFetch(jsonResponse(response));
+    await expect(
+      postCandles(BASE_CONFIG, VALID_CANDLES, "2026-05-01T00:00:00Z", { fetch })
+    ).rejects.toThrow(ProtocolError);
+  });
+
   it("throws ProtocolError for oversized body", async () => {
     const fetch = mockFetch(
       new Response("", {

--- a/src/workers/gecko/__tests__/ingestClient.test.ts
+++ b/src/workers/gecko/__tests__/ingestClient.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi } from "vitest";
+import { postCandles } from "../ingestClient.js";
+import { HttpError, ProtocolError, RequestTimeoutError, RequestTransportError } from "../retry.js";
+import type { GeckoCollectorConfig } from "../config.js";
+import { SCHEMA_VERSION } from "../../../contract/v1/types.js";
+
+const BASE_CONFIG: GeckoCollectorConfig = {
+  regimeEngineUrl: new URL("https://regime-engine.example/base"),
+  candlesIngestToken: "tok_ingest_abc",
+  geckoSource: "geckoterminal",
+  geckoNetwork: "solana",
+  geckoPoolAddress: "pool123",
+  geckoSymbol: "SOL/USDC",
+  geckoTimeframe: "1h",
+  geckoLookback: 200,
+  geckoPollIntervalMs: 300000,
+  geckoMaxCallsPerMinute: 6,
+  geckoRequestTimeoutMs: 10000
+};
+
+const VALID_CANDLES = [
+  { unixMs: 1714536000000, open: 100, high: 105, low: 98, close: 102, volume: 1000 }
+];
+
+const VALID_RESPONSE = {
+  schemaVersion: SCHEMA_VERSION,
+  insertedCount: 1,
+  revisedCount: 0,
+  idempotentCount: 0,
+  rejectedCount: 0,
+  rejections: []
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  const text = JSON.stringify(body);
+  return new Response(text, {
+    status,
+    headers: { "content-type": "application/json", "content-length": String(text.length) }
+  });
+}
+
+function mockFetch(response: Response | (() => Promise<Response>)): typeof globalThis.fetch {
+  if (typeof response === "function") {
+    return vi.fn(response);
+  }
+  return vi.fn(async () => response);
+}
+
+describe("postCandles", () => {
+  it("POSTs with X-Candles-Ingest-Token header", async () => {
+    const fetch = mockFetch(jsonResponse(VALID_RESPONSE));
+    const result = await postCandles(BASE_CONFIG, VALID_CANDLES, "2026-05-01T00:00:00Z", { fetch });
+    expect(result.insertedCount).toBe(1);
+
+    const opts = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+    expect(opts.method).toBe("POST");
+    const headers = opts.headers as Record<string, string>;
+    expect(headers["X-Candles-Ingest-Token"]).toBe("tok_ingest_abc");
+  });
+
+  it("treats rejectedCount > 0 as success", async () => {
+    const response = {
+      ...VALID_RESPONSE,
+      rejectedCount: 2,
+      rejections: [
+        {
+          unixMs: 1714536000000,
+          reason: "STALE_REVISION",
+          existingSourceRecordedAtIso: "2026-05-01T00:00:00Z"
+        }
+      ]
+    };
+    const fetch = mockFetch(jsonResponse(response));
+    const result = await postCandles(BASE_CONFIG, VALID_CANDLES, "2026-05-01T00:00:00Z", { fetch });
+    expect(result.rejectedCount).toBe(2);
+  });
+
+  it("returns 429 as retryable HttpError", async () => {
+    const fetch = mockFetch(new Response("rate limited", { status: 429 }));
+    await expect(
+      postCandles(BASE_CONFIG, VALID_CANDLES, "2026-05-01T00:00:00Z", { fetch })
+    ).rejects.toThrow(HttpError);
+    const err = await postCandles(BASE_CONFIG, VALID_CANDLES, "2026-05-01T00:00:00Z", {
+      fetch
+    }).catch((e) => e);
+    expect(err.retryable).toBe(true);
+  });
+
+  it("returns 502 as retryable HttpError", async () => {
+    const fetch = mockFetch(new Response("bad gateway", { status: 502 }));
+    await expect(
+      postCandles(BASE_CONFIG, VALID_CANDLES, "2026-05-01T00:00:00Z", { fetch })
+    ).rejects.toThrow(HttpError);
+  });
+
+  it("returns 401 as non-retryable HttpError", async () => {
+    const fetch = mockFetch(new Response("unauthorized", { status: 401 }));
+    await expect(
+      postCandles(BASE_CONFIG, VALID_CANDLES, "2026-05-01T00:00:00Z", { fetch })
+    ).rejects.toThrow(HttpError);
+    const err = await postCandles(BASE_CONFIG, VALID_CANDLES, "2026-05-01T00:00:00Z", {
+      fetch
+    }).catch((e) => e);
+    expect(err.retryable).toBe(false);
+  });
+
+  it("throws ProtocolError for wrong schemaVersion", async () => {
+    const response = { ...VALID_RESPONSE, schemaVersion: "0.9" };
+    const fetch = mockFetch(jsonResponse(response));
+    await expect(
+      postCandles(BASE_CONFIG, VALID_CANDLES, "2026-05-01T00:00:00Z", { fetch })
+    ).rejects.toThrow(ProtocolError);
+  });
+
+  it("throws ProtocolError for negative count", async () => {
+    const response = { ...VALID_RESPONSE, insertedCount: -1 };
+    const fetch = mockFetch(jsonResponse(response));
+    await expect(
+      postCandles(BASE_CONFIG, VALID_CANDLES, "2026-05-01T00:00:00Z", { fetch })
+    ).rejects.toThrow(ProtocolError);
+  });
+
+  it("throws ProtocolError for oversized body", async () => {
+    const fetch = mockFetch(
+      new Response("", {
+        status: 200,
+        headers: { "content-type": "application/json", "content-length": "600000" }
+      })
+    );
+    await expect(
+      postCandles(BASE_CONFIG, VALID_CANDLES, "2026-05-01T00:00:00Z", { fetch })
+    ).rejects.toThrow(ProtocolError);
+  });
+
+  it("throws RequestTimeoutError on timeout", async () => {
+    const fetch = vi.fn(async () => {
+      throw new DOMException("The operation was aborted", "TimeoutError");
+    });
+    await expect(
+      postCandles(BASE_CONFIG, VALID_CANDLES, "2026-05-01T00:00:00Z", { fetch })
+    ).rejects.toThrow(RequestTimeoutError);
+  });
+
+  it("throws RequestTransportError on TypeError", async () => {
+    const fetch = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    });
+    await expect(
+      postCandles(BASE_CONFIG, VALID_CANDLES, "2026-05-01T00:00:00Z", { fetch })
+    ).rejects.toThrow(RequestTransportError);
+  });
+});

--- a/src/workers/gecko/__tests__/ingestClient.test.ts
+++ b/src/workers/gecko/__tests__/ingestClient.test.ts
@@ -149,4 +149,19 @@ describe("postCandles", () => {
       postCandles(BASE_CONFIG, VALID_CANDLES, "2026-05-01T00:00:00Z", { fetch })
     ).rejects.toThrow(RequestTransportError);
   });
+
+  it("aborts in-flight request when shutdown signal fires", async () => {
+    const controller = new AbortController();
+    const fetch = vi.fn(async (_input: string | URL | Request, opts?: RequestInit) => {
+      expect(opts?.signal?.aborted).toBe(false);
+      controller.abort();
+      throw new DOMException("The operation was aborted", "AbortError");
+    });
+    await expect(
+      postCandles(BASE_CONFIG, VALID_CANDLES, "2026-05-01T00:00:00Z", {
+        fetch,
+        shutdownSignal: controller.signal
+      })
+    ).rejects.toThrow(RequestTimeoutError);
+  });
 });

--- a/src/workers/gecko/__tests__/logger.test.ts
+++ b/src/workers/gecko/__tests__/logger.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { redactLogContext } from "../logger.js";
+
+describe("redactLogContext", () => {
+  it("redacts top-level keys matching secret pattern", () => {
+    const result = redactLogContext({
+      token: "abc123",
+      status: "ok"
+    });
+    expect(result).toEqual({
+      token: "[REDACTED]",
+      status: "ok"
+    });
+  });
+
+  it("redacts nested keys matching secret pattern", () => {
+    const result = redactLogContext({
+      responseBody: { data: "sensitive" },
+      metadata: { authorization: "Bearer xyz", count: 5 }
+    });
+    expect(result).toEqual({
+      responseBody: "[REDACTED]",
+      metadata: {
+        authorization: "[REDACTED]",
+        count: 5
+      }
+    });
+  });
+
+  it("does not redact keys that do not match", () => {
+    const result = redactLogContext({
+      candles: 42,
+      network: "solana"
+    });
+    expect(result).toEqual({
+      candles: 42,
+      network: "solana"
+    });
+  });
+});

--- a/src/workers/gecko/__tests__/normalize.test.ts
+++ b/src/workers/gecko/__tests__/normalize.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect } from "vitest";
+import { normalizeGeckoOhlcv, shouldPostNormalizedBatch } from "../normalize.js";
+import type { NormalizationStats } from "../normalize.js";
+import type { GeckoCollectorConfig } from "../config.js";
+
+const BASE_CONFIG: GeckoCollectorConfig = {
+  regimeEngineUrl: new URL("https://regime-engine.example"),
+  candlesIngestToken: "tok_abc123",
+  geckoSource: "geckoterminal",
+  geckoNetwork: "solana",
+  geckoPoolAddress: "pool123",
+  geckoSymbol: "SOL/USDC",
+  geckoTimeframe: "1h",
+  geckoLookback: 200,
+  geckoPollIntervalMs: 300000,
+  geckoMaxCallsPerMinute: 6,
+  geckoRequestTimeoutMs: 10000
+};
+
+const VALID_PAYLOAD = {
+  data: {
+    attributes: {
+      ohlcv_list: [
+        [1714536000, 100, 105, 98, 102, 1000],
+        [1714539600, 102, 108, 100, 106, 1200]
+      ]
+    }
+  }
+};
+
+describe("normalizeGeckoOhlcv", () => {
+  it("converts Unix seconds to milliseconds", () => {
+    const { candles } = normalizeGeckoOhlcv(VALID_PAYLOAD, BASE_CONFIG);
+    expect(candles[0].unixMs).toBe(1714536000000);
+    expect(candles[1].unixMs).toBe(1714539600000);
+  });
+
+  it("throws ProtocolError for malformed envelope", () => {
+    expect(() => normalizeGeckoOhlcv({}, BASE_CONFIG)).toThrow(
+      "missing data.attributes.ohlcv_list"
+    );
+  });
+
+  it("throws ProtocolError for non-array ohlcv_list", () => {
+    expect(() =>
+      normalizeGeckoOhlcv({ data: { attributes: { ohlcv_list: "bad" } } }, BASE_CONFIG)
+    ).toThrow("ohlcv_list is not an array");
+  });
+
+  it("throws ProtocolError when >1000 rows returned", () => {
+    const rows = Array.from({ length: 1001 }, () => [1714536000, 1, 2, 3, 4, 5]);
+    expect(() =>
+      normalizeGeckoOhlcv({ data: { attributes: { ohlcv_list: rows } } }, BASE_CONFIG)
+    ).toThrow(">1000 rows");
+  });
+
+  it("drops rows that are not arrays of length 6", () => {
+    const payload = {
+      data: {
+        attributes: {
+          ohlcv_list: [
+            [1714536000, 1, 2, 3],
+            [1714539600, 1, 2, 3, 4, 5]
+          ]
+        }
+      }
+    };
+    const { stats } = normalizeGeckoOhlcv(payload, BASE_CONFIG);
+    expect(stats.malformedRowCount).toBe(1);
+    expect(stats.validCount).toBe(1);
+  });
+
+  it("drops rows with missing or extra fields", () => {
+    const payload = {
+      data: {
+        attributes: {
+          ohlcv_list: [
+            [1714536000, 1, 2, 3, 4],
+            [1714539600, 1, 2, 3, 4, 5, 6]
+          ]
+        }
+      }
+    };
+    const { stats } = normalizeGeckoOhlcv(payload, BASE_CONFIG);
+    expect(stats.malformedRowCount).toBe(2);
+  });
+
+  it("drops rows with non-finite OHLCV values", () => {
+    const payload = {
+      data: {
+        attributes: {
+          ohlcv_list: [
+            [1714536000, Infinity, 2, 3, 4, 5],
+            [1714539600, 1, NaN, 3, 4, 5]
+          ]
+        }
+      }
+    };
+    const { stats } = normalizeGeckoOhlcv(payload, BASE_CONFIG);
+    expect(stats.invalidOhlcvRowCount).toBe(2);
+  });
+
+  it("drops rows with unsafe integer timestamps", () => {
+    const unsafeTs = Number.MAX_SAFE_INTEGER + 1;
+    const payload = {
+      data: { attributes: { ohlcv_list: [[unsafeTs, 1, 2, 3, 4, 5]] } }
+    };
+    const { stats } = normalizeGeckoOhlcv(payload, BASE_CONFIG);
+    expect(stats.validCount).toBe(0);
+  });
+
+  it("drops rows with negative timestamps", () => {
+    const payload = {
+      data: { attributes: { ohlcv_list: [[-1, 1, 2, 3, 4, 5]] } }
+    };
+    const { stats } = normalizeGeckoOhlcv(payload, BASE_CONFIG);
+    expect(stats.validCount).toBe(0);
+  });
+
+  it("drops misaligned timestamps but still returns them for counting", () => {
+    const payload = {
+      data: { attributes: { ohlcv_list: [[1714536001, 1, 2, 3, 4, 5]] } }
+    };
+    const { stats } = normalizeGeckoOhlcv(payload, BASE_CONFIG);
+    expect(stats.misalignedRowCount).toBe(1);
+    expect(stats.validCount).toBe(0);
+  });
+
+  it("dedupes identical rows at same timestamp", () => {
+    const payload = {
+      data: {
+        attributes: {
+          ohlcv_list: [
+            [1714536000, 100, 105, 98, 102, 1000],
+            [1714536000, 100, 105, 98, 102, 1000]
+          ]
+        }
+      }
+    };
+    const { candles, stats } = normalizeGeckoOhlcv(payload, BASE_CONFIG);
+    expect(candles).toHaveLength(1);
+    expect(stats.duplicateIdenticalDroppedCount).toBe(1);
+  });
+
+  it("drops conflicting rows at same timestamp", () => {
+    const payload = {
+      data: {
+        attributes: {
+          ohlcv_list: [
+            [1714536000, 100, 105, 98, 102, 1000],
+            [1714536000, 200, 210, 190, 205, 2000]
+          ]
+        }
+      }
+    };
+    const { candles, stats } = normalizeGeckoOhlcv(payload, BASE_CONFIG);
+    expect(candles).toHaveLength(0);
+    expect(stats.duplicateConflictDroppedCount).toBe(2);
+    expect(stats.corruptionDroppedCount).toBe(2);
+  });
+
+  it("sorts candles by unixMs ascending", () => {
+    const payload = {
+      data: {
+        attributes: {
+          ohlcv_list: [
+            [1714539600, 102, 108, 100, 106, 1200],
+            [1714536000, 100, 105, 98, 102, 1000]
+          ]
+        }
+      }
+    };
+    const { candles } = normalizeGeckoOhlcv(payload, BASE_CONFIG);
+    expect(candles[0].unixMs).toBe(1714536000000);
+    expect(candles[1].unixMs).toBe(1714539600000);
+  });
+});
+
+describe("shouldPostNormalizedBatch", () => {
+  const makeStats = (overrides: Partial<NormalizationStats> = {}): NormalizationStats => ({
+    providerRowCount: 200,
+    malformedRowCount: 0,
+    misalignedRowCount: 0,
+    invalidOhlcvRowCount: 0,
+    duplicateIdenticalDroppedCount: 0,
+    duplicateConflictDroppedCount: 0,
+    totalDroppedCount: 0,
+    corruptionDroppedCount: 0,
+    validCount: 200,
+    dropReasons: [],
+    ...overrides
+  });
+
+  it("blocks when validCount is zero", () => {
+    const stats = makeStats({ validCount: 0, providerRowCount: 200 });
+    expect(shouldPostNormalizedBatch(stats, BASE_CONFIG)).toBe("zero_valid");
+  });
+
+  it("blocks when corruption rate exceeds 10%", () => {
+    const stats = makeStats({
+      providerRowCount: 200,
+      malformedRowCount: 21,
+      corruptionDroppedCount: 21,
+      totalDroppedCount: 21,
+      validCount: 179
+    });
+    expect(shouldPostNormalizedBatch(stats, BASE_CONFIG)).toBe("corruption_rate");
+  });
+
+  it("does not block when identical duplicates push drop rate above 10% (not corruption)", () => {
+    const stats = makeStats({
+      providerRowCount: 200,
+      duplicateIdenticalDroppedCount: 30,
+      totalDroppedCount: 30,
+      corruptionDroppedCount: 0,
+      validCount: 170
+    });
+    expect(shouldPostNormalizedBatch(stats, BASE_CONFIG)).toBeNull();
+  });
+
+  it("blocks when lookback >= 50 and validCount < 50", () => {
+    const stats = makeStats({
+      providerRowCount: 200,
+      validCount: 49,
+      totalDroppedCount: 151
+    });
+    expect(shouldPostNormalizedBatch(stats, BASE_CONFIG)).toBe("low_valid_count");
+  });
+
+  it("does not block low valid count when lookback < 50", () => {
+    const config = { ...BASE_CONFIG, geckoLookback: 30 };
+    const stats = makeStats({
+      providerRowCount: 200,
+      validCount: 25,
+      totalDroppedCount: 175
+    });
+    expect(shouldPostNormalizedBatch(stats, config)).toBeNull();
+  });
+});

--- a/src/workers/gecko/__tests__/normalize.test.ts
+++ b/src/workers/gecko/__tests__/normalize.test.ts
@@ -60,7 +60,7 @@ describe("normalizeGeckoOhlcv", () => {
         attributes: {
           ohlcv_list: [
             [1714536000, 1, 2, 3],
-            [1714539600, 1, 2, 3, 4, 5]
+            [1714539600, 1, 5, 0.5, 3, 4]
           ]
         }
       }

--- a/src/workers/gecko/__tests__/retry.test.ts
+++ b/src/workers/gecko/__tests__/retry.test.ts
@@ -135,6 +135,16 @@ describe("withRetry", () => {
     ).rejects.toThrow("HTTP 503");
     expect(operation).toHaveBeenCalledTimes(1);
   });
+  it("exhausts max attempts then throws", async () => {
+    const operation = vi.fn(async () => {
+      throw new HttpError(503, "retry");
+    });
+
+    await expect(withRetry(operation, { sleep: () => Promise.resolve() })).rejects.toThrow(
+      "HTTP 503"
+    );
+    expect(operation).toHaveBeenCalledTimes(3);
+  });
 });
 
 describe("createRateLimiter", () => {

--- a/src/workers/gecko/__tests__/retry.test.ts
+++ b/src/workers/gecko/__tests__/retry.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  HttpError,
+  ProtocolError,
+  RequestTransportError,
+  isRetryableHttpStatus,
+  withRetry,
+  createRateLimiter
+} from "../retry.js";
+
+describe("HttpError", () => {
+  it("stores statusCode and responseBody", () => {
+    const err = new HttpError(503, "Service Unavailable");
+    expect(err.statusCode).toBe(503);
+    expect(err.responseBody).toBe("Service Unavailable");
+    expect(err.name).toBe("HttpError");
+    expect(err.retryable).toBe(true);
+  });
+
+  it("allows explicit retryable override", () => {
+    const err = new HttpError(429, "rate limited", false);
+    expect(err.retryable).toBe(false);
+  });
+});
+
+describe("isRetryableHttpStatus", () => {
+  it("returns true for 429", () => {
+    expect(isRetryableHttpStatus(429)).toBe(true);
+  });
+
+  it("returns true for 500-504", () => {
+    expect(isRetryableHttpStatus(500)).toBe(true);
+    expect(isRetryableHttpStatus(502)).toBe(true);
+    expect(isRetryableHttpStatus(503)).toBe(true);
+    expect(isRetryableHttpStatus(504)).toBe(true);
+  });
+
+  it("returns false for 4xx client errors", () => {
+    expect(isRetryableHttpStatus(400)).toBe(false);
+    expect(isRetryableHttpStatus(401)).toBe(false);
+    expect(isRetryableHttpStatus(403)).toBe(false);
+    expect(isRetryableHttpStatus(404)).toBe(false);
+    expect(isRetryableHttpStatus(409)).toBe(false);
+  });
+});
+
+describe("withRetry", () => {
+  it("retries with exponential backoff and jitter", async () => {
+    const sleeps: number[] = [];
+    const sleep = (ms: number) => {
+      sleeps.push(ms);
+      return Promise.resolve();
+    };
+
+    let attempt = 0;
+    const operation = vi.fn(async () => {
+      attempt++;
+      if (attempt <= 2) throw new HttpError(503, "retry");
+      return "ok";
+    });
+
+    const result = await withRetry(operation, { sleep });
+    expect(result).toBe("ok");
+    expect(operation).toHaveBeenCalledTimes(3);
+    expect(sleeps).toHaveLength(2);
+    expect(sleeps[0]).toBe(1000 + 10);
+    expect(sleeps[1]).toBe(2000 + 20);
+  });
+
+  it("throws non-retryable HttpError on first attempt", async () => {
+    const operation = vi.fn(async () => {
+      throw new HttpError(404, "not found");
+    });
+
+    await expect(withRetry(operation)).rejects.toThrow("HTTP 404");
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws ProtocolError on first attempt", async () => {
+    const operation = vi.fn(async () => {
+      throw new ProtocolError("bad envelope");
+    });
+
+    await expect(withRetry(operation)).rejects.toThrow("bad envelope");
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws unclassified errors on first attempt", async () => {
+    const operation = vi.fn(async () => {
+      throw new TypeError("not a function");
+    });
+
+    await expect(withRetry(operation)).rejects.toThrow("not a function");
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries transport errors", async () => {
+    let attempt = 0;
+    const operation = vi.fn(async () => {
+      attempt++;
+      if (attempt <= 2) throw new RequestTransportError("ECONNRESET");
+      return "ok";
+    });
+
+    const result = await withRetry(operation, { sleep: () => Promise.resolve() });
+    expect(result).toBe("ok");
+    expect(operation).toHaveBeenCalledTimes(3);
+  });
+
+  it("exits promptly when abort during sleep", async () => {
+    const operation = vi.fn(async () => {
+      throw new HttpError(503, "retry");
+    });
+
+    const sleep = vi.fn(async () => {
+      throw new Error("aborted");
+    });
+    const controller = new AbortController();
+    controller.abort();
+    const signal = controller.signal;
+
+    await expect(withRetry(operation, { sleep, signal })).rejects.toThrow("HTTP 503");
+  });
+
+  it("stops before another attempt when shouldContinue=false", async () => {
+    let callCount = 0;
+    const operation = vi.fn(async () => {
+      callCount++;
+      throw new HttpError(503, "retry");
+    });
+
+    const shouldContinue = () => callCount < 1;
+    await expect(
+      withRetry(operation, { shouldContinue, sleep: () => Promise.resolve() })
+    ).rejects.toThrow("HTTP 503");
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createRateLimiter", () => {
+  it("first call is immediate, subsequent calls are spaced", async () => {
+    let currentTime = 0;
+    const now = () => currentTime;
+    const sleeps: number[] = [];
+    const sleep = (ms: number) => {
+      sleeps.push(ms);
+      currentTime += ms;
+      return Promise.resolve();
+    };
+
+    const limiter = createRateLimiter(6, { sleep, now });
+    await limiter.waitForPermit();
+    expect(sleeps).toHaveLength(0);
+
+    currentTime = 5000;
+    await limiter.waitForPermit();
+    expect(sleeps).toHaveLength(1);
+    expect(sleeps[0]).toBe(5000);
+  });
+});

--- a/src/workers/gecko/config.ts
+++ b/src/workers/gecko/config.ts
@@ -1,0 +1,116 @@
+export type GeckoCollectorConfig = {
+  regimeEngineUrl: URL;
+  candlesIngestToken: string;
+  geckoSource: string;
+  geckoNetwork: string;
+  geckoPoolAddress: string;
+  geckoSymbol: string;
+  geckoTimeframe: string;
+  geckoLookback: number;
+  geckoPollIntervalMs: number;
+  geckoMaxCallsPerMinute: number;
+  geckoRequestTimeoutMs: number;
+};
+
+const ALLOWED_HTTP_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+const RAILWAY_INTERNAL_SUFFIX = ".railway.internal";
+
+function isAllowedHttpHost(hostname: string): boolean {
+  if (ALLOWED_HTTP_HOSTS.has(hostname)) return true;
+  if (hostname.endsWith(RAILWAY_INTERNAL_SUFFIX)) return true;
+  return false;
+}
+
+function readRequired(env: Record<string, string | undefined>, key: string): string {
+  const value = env[key];
+  if (value === undefined || value === "") {
+    throw new Error(`Missing required env: ${key}`);
+  }
+  return value;
+}
+
+function readLiteral<T extends string>(
+  env: Record<string, string | undefined>,
+  key: string,
+  allowed: readonly T[],
+  defaultValue: T
+): T {
+  const raw = env[key];
+  if (raw === undefined || raw === "") return defaultValue;
+  if (!allowed.includes(raw as T)) {
+    throw new Error(`Unsupported ${key}: ${raw}. Allowed: ${allowed.join(", ")}`);
+  }
+  return raw as T;
+}
+
+function readPositiveInteger(
+  env: Record<string, string | undefined>,
+  key: string,
+  defaultValue: number
+): number {
+  const raw = env[key];
+  if (raw === undefined || raw === "") return defaultValue;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error(`${key} must be a positive integer, got: ${raw}`);
+  }
+  return n;
+}
+
+function readLookback(
+  env: Record<string, string | undefined>,
+  key: string,
+  defaultValue: number,
+  max: number
+): number {
+  const raw = env[key];
+  if (raw === undefined || raw === "") return defaultValue;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1 || n > max) {
+    throw new Error(`${key} must be a positive integer ≤ ${max}, got: ${raw}`);
+  }
+  return n;
+}
+
+function readPoolAddress(env: Record<string, string | undefined>, key: string): string {
+  const value = readRequired(env, key);
+  if (/<|>/.test(value)) {
+    throw new Error(`${key} contains placeholder characters: ${value}`);
+  }
+  return value;
+}
+
+function readAbsoluteUrl(env: Record<string, string | undefined>, key: string): URL {
+  const raw = readRequired(env, key);
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(`${key} is not a valid absolute URL: ${raw}`);
+  }
+  if (url.protocol !== "https:" && !isAllowedHttpHost(url.hostname)) {
+    throw new Error(
+      `${key} must use HTTPS (got ${url.protocol}). HTTP is only allowed for localhost or *.railway.internal`
+    );
+  }
+  return url;
+}
+
+export function parseGeckoCollectorConfig(
+  env: Record<string, string | undefined>
+): GeckoCollectorConfig {
+  return {
+    regimeEngineUrl: readAbsoluteUrl(env, "REGIME_ENGINE_URL"),
+    candlesIngestToken: readRequired(env, "CANDLES_INGEST_TOKEN"),
+    geckoSource: readLiteral(env, "GECKO_SOURCE", ["geckoterminal"] as const, "geckoterminal"),
+    geckoNetwork: readLiteral(env, "GECKO_NETWORK", ["solana"] as const, "solana"),
+    geckoPoolAddress: readPoolAddress(env, "GECKO_POOL_ADDRESS"),
+    geckoSymbol: readLiteral(env, "GECKO_SYMBOL", ["SOL/USDC"] as const, "SOL/USDC"),
+    geckoTimeframe: readLiteral(env, "GECKO_TIMEFRAME", ["1h"] as const, "1h"),
+    geckoLookback: readLookback(env, "GECKO_LOOKBACK", 200, 1000),
+    geckoPollIntervalMs: readPositiveInteger(env, "GECKO_POLL_INTERVAL_MS", 300000),
+    geckoMaxCallsPerMinute: readPositiveInteger(env, "GECKO_MAX_CALLS_PER_MINUTE", 6),
+    geckoRequestTimeoutMs: readPositiveInteger(env, "GECKO_REQUEST_TIMEOUT_MS", 10000)
+  };
+}

--- a/src/workers/gecko/config.ts
+++ b/src/workers/gecko/config.ts
@@ -94,6 +94,11 @@ function readAbsoluteUrl(env: Record<string, string | undefined>, key: string): 
       `${key} must use HTTPS (got ${url.protocol}). HTTP is only allowed for localhost or *.railway.internal`
     );
   }
+  if (url.pathname !== "/" && url.pathname !== "") {
+    throw new Error(
+      `${key} must not contain a path component (got ${url.pathname}). The collector appends paths internally.`
+    );
+  }
   return url;
 }
 

--- a/src/workers/gecko/config.ts
+++ b/src/workers/gecko/config.ts
@@ -89,7 +89,7 @@ function readAbsoluteUrl(env: Record<string, string | undefined>, key: string): 
   } catch {
     throw new Error(`${key} is not a valid absolute URL: ${raw}`);
   }
-  if (url.protocol !== "https:" && !isAllowedHttpHost(url.hostname)) {
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && isAllowedHttpHost(url.hostname))) {
     throw new Error(
       `${key} must use HTTPS (got ${url.protocol}). HTTP is only allowed for localhost or *.railway.internal`
     );

--- a/src/workers/gecko/geckoClient.ts
+++ b/src/workers/gecko/geckoClient.ts
@@ -1,7 +1,6 @@
 import type { GeckoCollectorConfig } from "./config.js";
-import { HttpError, ProtocolError, RequestTimeoutError, RequestTransportError } from "./retry.js";
-
-const MAX_BODY_BYTES = 512 * 1024;
+import { HttpError, RequestTimeoutError, RequestTransportError } from "./retry.js";
+import { readTextWithLimit, parseJson, readErrorBody } from "./httpUtils.js";
 
 export type GeckoClientDeps = {
   waitForProviderPermit?: () => Promise<void>;
@@ -16,35 +15,6 @@ function buildGeckoUrl(config: GeckoCollectorConfig): URL {
   url.searchParams.set("aggregate", "1");
   url.searchParams.set("limit", String(config.geckoLookback));
   return url;
-}
-
-async function readTextWithLimit(response: Response): Promise<string> {
-  const contentLength = response.headers.get("content-length");
-  if (contentLength !== null) {
-    const length = Number(contentLength);
-    if (Number.isFinite(length) && length > MAX_BODY_BYTES) {
-      throw new ProtocolError(
-        `Response body exceeds ${MAX_BODY_BYTES} bytes (Content-Length: ${length})`
-      );
-    }
-  }
-  const text = await response.text();
-  if (text.length > MAX_BODY_BYTES) {
-    throw new ProtocolError(
-      `Response body exceeds ${MAX_BODY_BYTES} bytes (actual: ${text.length})`
-    );
-  }
-  return text;
-}
-
-function parseJson(text: string): unknown {
-  try {
-    return JSON.parse(text);
-  } catch (err: unknown) {
-    throw new ProtocolError(
-      `Invalid JSON from GeckoTerminal: ${err instanceof Error ? err.message : String(err)}`
-    );
-  }
 }
 
 export async function fetchGeckoOhlcv(
@@ -79,10 +49,10 @@ export async function fetchGeckoOhlcv(
   }
 
   if (!response.ok) {
-    const body = await response.text().catch(() => "");
+    const body = await readErrorBody(response);
     throw new HttpError(response.status, body);
   }
 
   const text = await readTextWithLimit(response);
-  return parseJson(text);
+  return parseJson(text, "GeckoTerminal");
 }

--- a/src/workers/gecko/geckoClient.ts
+++ b/src/workers/gecko/geckoClient.ts
@@ -1,0 +1,88 @@
+import type { GeckoCollectorConfig } from "./config.js";
+import { HttpError, ProtocolError, RequestTimeoutError, RequestTransportError } from "./retry.js";
+
+const MAX_BODY_BYTES = 512 * 1024;
+
+export type GeckoClientDeps = {
+  waitForProviderPermit?: () => Promise<void>;
+  fetch?: typeof globalThis.fetch;
+  AbortSignal?: typeof globalThis.AbortSignal;
+};
+
+function buildGeckoUrl(config: GeckoCollectorConfig): URL {
+  const base = "https://api.geckoterminal.com";
+  const path = `/api/v2/networks/${encodeURIComponent(config.geckoNetwork)}/pools/${encodeURIComponent(config.geckoPoolAddress)}/ohlcv/hour`;
+  const url = new URL(path, base);
+  url.searchParams.set("aggregate", "1");
+  url.searchParams.set("limit", String(config.geckoLookback));
+  return url;
+}
+
+async function readTextWithLimit(response: Response): Promise<string> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null) {
+    const length = Number(contentLength);
+    if (Number.isFinite(length) && length > MAX_BODY_BYTES) {
+      throw new ProtocolError(
+        `Response body exceeds ${MAX_BODY_BYTES} bytes (Content-Length: ${length})`
+      );
+    }
+  }
+  const text = await response.text();
+  if (text.length > MAX_BODY_BYTES) {
+    throw new ProtocolError(
+      `Response body exceeds ${MAX_BODY_BYTES} bytes (actual: ${text.length})`
+    );
+  }
+  return text;
+}
+
+function parseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch (err: unknown) {
+    throw new ProtocolError(
+      `Invalid JSON from GeckoTerminal: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
+
+export async function fetchGeckoOhlcv(
+  config: GeckoCollectorConfig,
+  deps?: GeckoClientDeps
+): Promise<unknown> {
+  const waitForPermit = deps?.waitForProviderPermit ?? (() => Promise.resolve());
+  const fetchFn = deps?.fetch ?? globalThis.fetch;
+  const AbortSignalCtor = deps?.AbortSignal ?? globalThis.AbortSignal;
+
+  await waitForPermit();
+
+  const url = buildGeckoUrl(config);
+  const signal = AbortSignalCtor.timeout(config.geckoRequestTimeoutMs);
+
+  let response: Response;
+  try {
+    response = await fetchFn(url.href, {
+      headers: { Accept: "application/json" },
+      signal
+    });
+  } catch (err: unknown) {
+    if (err instanceof DOMException && (err.name === "AbortError" || err.name === "TimeoutError")) {
+      throw new RequestTimeoutError(
+        `GeckoTerminal request timed out after ${config.geckoRequestTimeoutMs}ms`
+      );
+    }
+    if (err instanceof TypeError) {
+      throw new RequestTransportError(`GeckoTerminal transport error: ${err.message}`);
+    }
+    throw err;
+  }
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new HttpError(response.status, body);
+  }
+
+  const text = await readTextWithLimit(response);
+  return parseJson(text);
+}

--- a/src/workers/gecko/geckoClient.ts
+++ b/src/workers/gecko/geckoClient.ts
@@ -6,6 +6,7 @@ export type GeckoClientDeps = {
   waitForProviderPermit?: () => Promise<void>;
   fetch?: typeof globalThis.fetch;
   AbortSignal?: typeof globalThis.AbortSignal;
+  shutdownSignal?: AbortSignal;
 };
 
 function buildGeckoUrl(config: GeckoCollectorConfig): URL {
@@ -28,7 +29,10 @@ export async function fetchGeckoOhlcv(
   await waitForPermit();
 
   const url = buildGeckoUrl(config);
-  const signal = AbortSignalCtor.timeout(config.geckoRequestTimeoutMs);
+  const timeoutSignal = AbortSignalCtor.timeout(config.geckoRequestTimeoutMs);
+  const signal = deps?.shutdownSignal
+    ? AbortSignalCtor.any([timeoutSignal, deps.shutdownSignal])
+    : timeoutSignal;
 
   let response: Response;
   try {

--- a/src/workers/gecko/httpUtils.ts
+++ b/src/workers/gecko/httpUtils.ts
@@ -12,13 +12,35 @@ export async function readTextWithLimit(response: Response): Promise<string> {
       );
     }
   }
-  const text = await response.text();
-  if (text.length > MAX_BODY_BYTES) {
-    throw new ProtocolError(
-      `Response body exceeds ${MAX_BODY_BYTES} bytes (actual: ${text.length})`
-    );
+  if (!response.body) {
+    const text = await response.text();
+    if (text.length > MAX_BODY_BYTES) {
+      throw new ProtocolError(
+        `Response body exceeds ${MAX_BODY_BYTES} bytes (actual: ${text.length})`
+      );
+    }
+    return text;
   }
-  return text;
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  const reader = response.body.getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_BODY_BYTES) {
+        throw new ProtocolError(
+          `Response body exceeds ${MAX_BODY_BYTES} bytes (streamed: ${totalBytes})`
+        );
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const decoder = new TextDecoder();
+  return chunks.map((c) => decoder.decode(c, { stream: true })).join("") + decoder.decode();
 }
 
 export function parseJson(text: string, source: string): unknown {

--- a/src/workers/gecko/httpUtils.ts
+++ b/src/workers/gecko/httpUtils.ts
@@ -1,0 +1,44 @@
+import { ProtocolError } from "./retry.js";
+
+const MAX_BODY_BYTES = 512 * 1024;
+
+export async function readTextWithLimit(response: Response): Promise<string> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null) {
+    const length = Number(contentLength);
+    if (Number.isFinite(length) && length > MAX_BODY_BYTES) {
+      throw new ProtocolError(
+        `Response body exceeds ${MAX_BODY_BYTES} bytes (Content-Length: ${length})`
+      );
+    }
+  }
+  const text = await response.text();
+  if (text.length > MAX_BODY_BYTES) {
+    throw new ProtocolError(
+      `Response body exceeds ${MAX_BODY_BYTES} bytes (actual: ${text.length})`
+    );
+  }
+  return text;
+}
+
+export function parseJson(text: string, source: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch (err: unknown) {
+    throw new ProtocolError(
+      `Invalid JSON from ${source}: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
+
+export async function readErrorBody(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    if (text.length > MAX_BODY_BYTES) {
+      return text.slice(0, 1024);
+    }
+    return text;
+  } catch {
+    return "";
+  }
+}

--- a/src/workers/gecko/httpUtils.ts
+++ b/src/workers/gecko/httpUtils.ts
@@ -68,6 +68,7 @@ export async function readErrorBody(response: Response): Promise<string> {
     }
     const chunks: Uint8Array[] = [];
     let totalBytes = 0;
+    let retainedBytes = 0;
     const maxErrorBytes = 1024;
     const reader = response.body.getReader();
     try {
@@ -78,8 +79,9 @@ export async function readErrorBody(response: Response): Promise<string> {
         if (totalBytes > MAX_BODY_BYTES) {
           break;
         }
-        if (chunks.reduce((s, c) => s + c.byteLength, 0) < maxErrorBytes) {
+        if (retainedBytes < maxErrorBytes) {
           chunks.push(value);
+          retainedBytes += value.byteLength;
         }
       }
     } finally {

--- a/src/workers/gecko/httpUtils.ts
+++ b/src/workers/gecko/httpUtils.ts
@@ -55,11 +55,40 @@ export function parseJson(text: string, source: string): unknown {
 
 export async function readErrorBody(response: Response): Promise<string> {
   try {
-    const text = await response.text();
-    if (text.length > MAX_BODY_BYTES) {
-      return text.slice(0, 1024);
+    const contentLength = response.headers.get("content-length");
+    if (contentLength !== null) {
+      const length = Number(contentLength);
+      if (Number.isFinite(length) && length > MAX_BODY_BYTES) {
+        return "";
+      }
     }
-    return text;
+    if (!response.body) {
+      const text = await response.text();
+      return text.length > 1024 ? text.slice(0, 1024) : text;
+    }
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+    const maxErrorBytes = 1024;
+    const reader = response.body.getReader();
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        totalBytes += value.byteLength;
+        if (totalBytes > MAX_BODY_BYTES) {
+          break;
+        }
+        if (chunks.reduce((s, c) => s + c.byteLength, 0) < maxErrorBytes) {
+          chunks.push(value);
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+    if (totalBytes > MAX_BODY_BYTES) return "";
+    const decoder = new TextDecoder();
+    const text = chunks.map((c) => decoder.decode(c, { stream: true })).join("") + decoder.decode();
+    return text.length > 1024 ? text.slice(0, 1024) : text;
   } catch {
     return "";
   }

--- a/src/workers/gecko/ingestClient.ts
+++ b/src/workers/gecko/ingestClient.ts
@@ -1,0 +1,157 @@
+import { SCHEMA_VERSION, type Candle, type CandleIngestResponse } from "../../contract/v1/types.js";
+import type { GeckoCollectorConfig } from "./config.js";
+import { HttpError, ProtocolError, RequestTimeoutError, RequestTransportError } from "./retry.js";
+
+const MAX_BODY_BYTES = 512 * 1024;
+
+export type IngestClientDeps = {
+  fetch?: typeof globalThis.fetch;
+  AbortSignal?: typeof globalThis.AbortSignal;
+};
+
+function nonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function validateResponse(data: unknown): CandleIngestResponse {
+  if (data === null || typeof data !== "object") {
+    throw new ProtocolError("Invalid ingest response: not an object");
+  }
+
+  const obj = data as Record<string, unknown>;
+
+  if (obj.schemaVersion !== SCHEMA_VERSION) {
+    throw new ProtocolError(
+      `Invalid ingest response schemaVersion: expected ${SCHEMA_VERSION}, got ${obj.schemaVersion}`
+    );
+  }
+
+  if (!nonNegativeInteger(obj.insertedCount)) {
+    throw new ProtocolError(
+      "Invalid ingest response: insertedCount must be a non-negative integer"
+    );
+  }
+  if (!nonNegativeInteger(obj.revisedCount)) {
+    throw new ProtocolError("Invalid ingest response: revisedCount must be a non-negative integer");
+  }
+  if (!nonNegativeInteger(obj.idempotentCount)) {
+    throw new ProtocolError(
+      "Invalid ingest response: idempotentCount must be a non-negative integer"
+    );
+  }
+  if (!nonNegativeInteger(obj.rejectedCount)) {
+    throw new ProtocolError(
+      "Invalid ingest response: rejectedCount must be a non-negative integer"
+    );
+  }
+
+  if (!Array.isArray(obj.rejections)) {
+    throw new ProtocolError("Invalid ingest response: rejections must be an array");
+  }
+
+  for (const rejection of obj.rejections) {
+    if (rejection === null || typeof rejection !== "object") {
+      throw new ProtocolError("Invalid ingest response: each rejection must be an object");
+    }
+    const r = rejection as Record<string, unknown>;
+    if (typeof r.unixMs !== "number" || !Number.isInteger(r.unixMs)) {
+      throw new ProtocolError("Invalid ingest response: rejection.unixMs must be an integer");
+    }
+    if (typeof r.reason !== "string") {
+      throw new ProtocolError("Invalid ingest response: rejection.reason must be a string");
+    }
+    if (typeof r.existingSourceRecordedAtIso !== "string") {
+      throw new ProtocolError(
+        "Invalid ingest response: rejection.existingSourceRecordedAtIso must be a string"
+      );
+    }
+  }
+
+  return obj as unknown as CandleIngestResponse;
+}
+
+async function readTextWithLimit(response: Response): Promise<string> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null) {
+    const length = Number(contentLength);
+    if (Number.isFinite(length) && length > MAX_BODY_BYTES) {
+      throw new ProtocolError(
+        `Response body exceeds ${MAX_BODY_BYTES} bytes (Content-Length: ${length})`
+      );
+    }
+  }
+  const text = await response.text();
+  if (text.length > MAX_BODY_BYTES) {
+    throw new ProtocolError(
+      `Response body exceeds ${MAX_BODY_BYTES} bytes (actual: ${text.length})`
+    );
+  }
+  return text;
+}
+
+function parseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch (err: unknown) {
+    throw new ProtocolError(
+      `Invalid JSON from regime engine: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
+
+export async function postCandles(
+  config: GeckoCollectorConfig,
+  candles: Candle[],
+  sourceRecordedAtIso: string,
+  deps?: IngestClientDeps
+): Promise<CandleIngestResponse> {
+  const fetchFn = deps?.fetch ?? globalThis.fetch;
+  const AbortSignalCtor = deps?.AbortSignal ?? globalThis.AbortSignal;
+
+  const url = new URL("/v1/candles", config.regimeEngineUrl);
+
+  const payload = {
+    schemaVersion: SCHEMA_VERSION,
+    source: config.geckoSource,
+    network: config.geckoNetwork,
+    poolAddress: config.geckoPoolAddress,
+    symbol: config.geckoSymbol,
+    timeframe: config.geckoTimeframe,
+    sourceRecordedAtIso,
+    candles
+  };
+
+  const signal = AbortSignalCtor.timeout(config.geckoRequestTimeoutMs);
+
+  let response: Response;
+  try {
+    response = await fetchFn(url.href, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Candles-Ingest-Token": config.candlesIngestToken
+      },
+      body: JSON.stringify(payload),
+      signal
+    });
+  } catch (err: unknown) {
+    if (err instanceof DOMException && (err.name === "AbortError" || err.name === "TimeoutError")) {
+      throw new RequestTimeoutError(
+        `Ingest request timed out after ${config.geckoRequestTimeoutMs}ms`
+      );
+    }
+    if (err instanceof TypeError) {
+      throw new RequestTransportError(`Ingest transport error: ${err.message}`);
+    }
+    throw err;
+  }
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new HttpError(response.status, body);
+  }
+
+  const text = await readTextWithLimit(response);
+  const data = parseJson(text);
+  return validateResponse(data);
+}

--- a/src/workers/gecko/ingestClient.ts
+++ b/src/workers/gecko/ingestClient.ts
@@ -57,8 +57,10 @@ function validateResponse(data: unknown): CandleIngestResponse {
     if (typeof r.unixMs !== "number" || !Number.isInteger(r.unixMs)) {
       throw new ProtocolError("Invalid ingest response: rejection.unixMs must be an integer");
     }
-    if (typeof r.reason !== "string") {
-      throw new ProtocolError("Invalid ingest response: rejection.reason must be a string");
+    if (r.reason !== "STALE_REVISION") {
+      throw new ProtocolError(
+        `Invalid ingest response: rejection.reason must be "STALE_REVISION", got "${r.reason}"`
+      );
     }
     if (typeof r.existingSourceRecordedAtIso !== "string") {
       throw new ProtocolError(

--- a/src/workers/gecko/ingestClient.ts
+++ b/src/workers/gecko/ingestClient.ts
@@ -6,6 +6,7 @@ import { readTextWithLimit, parseJson, readErrorBody } from "./httpUtils.js";
 export type IngestClientDeps = {
   fetch?: typeof globalThis.fetch;
   AbortSignal?: typeof globalThis.AbortSignal;
+  shutdownSignal?: AbortSignal;
 };
 
 function nonNegativeInteger(value: unknown): value is number {
@@ -91,7 +92,10 @@ export async function postCandles(
     candles
   };
 
-  const signal = AbortSignalCtor.timeout(config.geckoRequestTimeoutMs);
+  const timeoutSignal = AbortSignalCtor.timeout(config.geckoRequestTimeoutMs);
+  const signal = deps?.shutdownSignal
+    ? AbortSignalCtor.any([timeoutSignal, deps.shutdownSignal])
+    : timeoutSignal;
 
   let response: Response;
   try {

--- a/src/workers/gecko/ingestClient.ts
+++ b/src/workers/gecko/ingestClient.ts
@@ -1,8 +1,7 @@
 import { SCHEMA_VERSION, type Candle, type CandleIngestResponse } from "../../contract/v1/types.js";
 import type { GeckoCollectorConfig } from "./config.js";
 import { HttpError, ProtocolError, RequestTimeoutError, RequestTransportError } from "./retry.js";
-
-const MAX_BODY_BYTES = 512 * 1024;
+import { readTextWithLimit, parseJson, readErrorBody } from "./httpUtils.js";
 
 export type IngestClientDeps = {
   fetch?: typeof globalThis.fetch;
@@ -70,35 +69,6 @@ function validateResponse(data: unknown): CandleIngestResponse {
   return obj as unknown as CandleIngestResponse;
 }
 
-async function readTextWithLimit(response: Response): Promise<string> {
-  const contentLength = response.headers.get("content-length");
-  if (contentLength !== null) {
-    const length = Number(contentLength);
-    if (Number.isFinite(length) && length > MAX_BODY_BYTES) {
-      throw new ProtocolError(
-        `Response body exceeds ${MAX_BODY_BYTES} bytes (Content-Length: ${length})`
-      );
-    }
-  }
-  const text = await response.text();
-  if (text.length > MAX_BODY_BYTES) {
-    throw new ProtocolError(
-      `Response body exceeds ${MAX_BODY_BYTES} bytes (actual: ${text.length})`
-    );
-  }
-  return text;
-}
-
-function parseJson(text: string): unknown {
-  try {
-    return JSON.parse(text);
-  } catch (err: unknown) {
-    throw new ProtocolError(
-      `Invalid JSON from regime engine: ${err instanceof Error ? err.message : String(err)}`
-    );
-  }
-}
-
 export async function postCandles(
   config: GeckoCollectorConfig,
   candles: Candle[],
@@ -147,11 +117,11 @@ export async function postCandles(
   }
 
   if (!response.ok) {
-    const body = await response.text().catch(() => "");
+    const body = await readErrorBody(response);
     throw new HttpError(response.status, body);
   }
 
   const text = await readTextWithLimit(response);
-  const data = parseJson(text);
+  const data = parseJson(text, "regime engine");
   return validateResponse(data);
 }

--- a/src/workers/gecko/logger.ts
+++ b/src/workers/gecko/logger.ts
@@ -1,0 +1,54 @@
+export type WorkerLogger = {
+  info(event: string, context?: Record<string, unknown>): void;
+  warn(event: string, context?: Record<string, unknown>): void;
+  error(event: string, context?: Record<string, unknown>): void;
+};
+
+const SECRET_KEY_PATTERN = /(token|secret|authorization|headers|responseBody)/i;
+
+export function redactLogContext(context: Record<string, unknown>): Record<string, unknown> {
+  const redacted: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(context)) {
+    if (SECRET_KEY_PATTERN.test(key)) {
+      redacted[key] = "[REDACTED]";
+    } else if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      redacted[key] = redactLogContext(value as Record<string, unknown>);
+    } else {
+      redacted[key] = value;
+    }
+  }
+  return redacted;
+}
+
+export const consoleLogger: WorkerLogger = {
+  info(event, context) {
+    console.log(
+      JSON.stringify({
+        level: "info",
+        event,
+        at: new Date().toISOString(),
+        ...redactLogContext(context ?? {})
+      })
+    );
+  },
+  warn(event, context) {
+    console.warn(
+      JSON.stringify({
+        level: "warn",
+        event,
+        at: new Date().toISOString(),
+        ...redactLogContext(context ?? {})
+      })
+    );
+  },
+  error(event, context) {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        event,
+        at: new Date().toISOString(),
+        ...redactLogContext(context ?? {})
+      })
+    );
+  }
+};

--- a/src/workers/gecko/normalize.ts
+++ b/src/workers/gecko/normalize.ts
@@ -52,6 +52,8 @@ function parseRow(
 
   if (o < 0 || h < 0 || l < 0 || c < 0 || v < 0) return null;
 
+  if (h < Math.max(o, c, l) || l > Math.min(o, c, h)) return null;
+
   return { candle: { unixMs, open: o, high: h, low: l, close: c, volume: v } };
 }
 

--- a/src/workers/gecko/normalize.ts
+++ b/src/workers/gecko/normalize.ts
@@ -1,0 +1,181 @@
+import type { Candle } from "../../contract/v1/types.js";
+import type { GeckoCollectorConfig } from "./config.js";
+import { ProtocolError } from "./retry.js";
+
+const TIMEFRAME_MS: Record<string, number> = {
+  "1h": 3600000
+};
+
+export type NormalizationStats = {
+  providerRowCount: number;
+  malformedRowCount: number;
+  misalignedRowCount: number;
+  invalidOhlcvRowCount: number;
+  duplicateIdenticalDroppedCount: number;
+  duplicateConflictDroppedCount: number;
+  totalDroppedCount: number;
+  corruptionDroppedCount: number;
+  validCount: number;
+  dropReasons: string[];
+};
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+function parseRow(
+  raw: unknown,
+  timeframeMs: number
+): { candle: Candle; dropReason?: string } | null {
+  if (!Array.isArray(raw)) return null;
+  if (raw.length !== 6) return null;
+
+  const [ts, o, h, l, c, v] = raw;
+
+  if (typeof ts !== "number" || !Number.isFinite(ts)) return null;
+  if (typeof o !== "number" || !Number.isFinite(o)) return null;
+  if (typeof h !== "number" || !Number.isFinite(h)) return null;
+  if (typeof l !== "number" || !Number.isFinite(l)) return null;
+  if (typeof c !== "number" || !Number.isFinite(c)) return null;
+  if (typeof v !== "number" || !Number.isFinite(v)) return null;
+
+  if (!Number.isSafeInteger(ts)) return null;
+  if (ts < 0) return null;
+
+  const unixMs = ts * 1000;
+  if (!Number.isSafeInteger(unixMs)) return null;
+  if (unixMs % timeframeMs !== 0)
+    return {
+      candle: { unixMs, open: o, high: h, low: l, close: c, volume: v },
+      dropReason: "misaligned"
+    };
+
+  if (o < 0 || h < 0 || l < 0 || c < 0 || v < 0) return null;
+
+  return { candle: { unixMs, open: o, high: h, low: l, close: c, volume: v } };
+}
+
+export function normalizeGeckoOhlcv(
+  payload: unknown,
+  config: GeckoCollectorConfig
+): { candles: Candle[]; stats: NormalizationStats } {
+  if (
+    !isObject(payload) ||
+    !isObject(payload.data) ||
+    !isObject(payload.data.attributes) ||
+    !("ohlcv_list" in payload.data.attributes)
+  ) {
+    throw new ProtocolError("Invalid GeckoTerminal envelope: missing data.attributes.ohlcv_list");
+  }
+
+  const ohlcvList = payload.data.attributes.ohlcv_list;
+
+  if (!Array.isArray(ohlcvList)) {
+    throw new ProtocolError("Invalid GeckoTerminal envelope: ohlcv_list is not an array");
+  }
+
+  if (ohlcvList.length > 1000) {
+    throw new ProtocolError("GeckoTerminal returned >1000 rows");
+  }
+
+  const timeframeMs = TIMEFRAME_MS[config.geckoTimeframe] ?? 3600000;
+
+  const stats: NormalizationStats = {
+    providerRowCount: ohlcvList.length,
+    malformedRowCount: 0,
+    misalignedRowCount: 0,
+    invalidOhlcvRowCount: 0,
+    duplicateIdenticalDroppedCount: 0,
+    duplicateConflictDroppedCount: 0,
+    totalDroppedCount: 0,
+    corruptionDroppedCount: 0,
+    validCount: 0,
+    dropReasons: []
+  };
+
+  const parsed: Map<number, Candle[]> = new Map();
+
+  for (const raw of ohlcvList) {
+    const result = parseRow(raw, timeframeMs);
+    if (result === null) {
+      if (!Array.isArray(raw) || raw.length !== 6) {
+        stats.malformedRowCount++;
+        stats.dropReasons.push("malformed");
+      } else {
+        stats.invalidOhlcvRowCount++;
+        stats.dropReasons.push("invalid_ohlcv");
+      }
+      continue;
+    }
+
+    if (result.dropReason === "misaligned") {
+      stats.misalignedRowCount++;
+      stats.dropReasons.push("misaligned");
+    }
+
+    if (result.dropReason) continue;
+
+    const existing = parsed.get(result.candle.unixMs);
+    if (existing) {
+      existing.push(result.candle);
+    } else {
+      parsed.set(result.candle.unixMs, [result.candle]);
+    }
+  }
+
+  const candles: Candle[] = [];
+  const sortedKeys = [...parsed.keys()].sort((a, b) => a - b);
+
+  for (const unixMs of sortedKeys) {
+    const group = parsed.get(unixMs)!;
+    if (group.length === 1) {
+      candles.push(group[0]);
+    } else {
+      const allIdentical = group.every(
+        (c) =>
+          c.open === group[0].open &&
+          c.high === group[0].high &&
+          c.low === group[0].low &&
+          c.close === group[0].close &&
+          c.volume === group[0].volume
+      );
+      if (allIdentical) {
+        candles.push(group[0]);
+        stats.duplicateIdenticalDroppedCount += group.length - 1;
+        stats.dropReasons.push(...Array(group.length - 1).fill("duplicate_identical"));
+      } else {
+        stats.duplicateConflictDroppedCount += group.length;
+        stats.dropReasons.push(...Array(group.length).fill("duplicate_conflict"));
+      }
+    }
+  }
+
+  stats.corruptionDroppedCount =
+    stats.malformedRowCount +
+    stats.misalignedRowCount +
+    stats.invalidOhlcvRowCount +
+    stats.duplicateConflictDroppedCount;
+
+  stats.validCount = candles.length;
+  stats.totalDroppedCount =
+    stats.malformedRowCount +
+    stats.misalignedRowCount +
+    stats.invalidOhlcvRowCount +
+    stats.duplicateIdenticalDroppedCount +
+    stats.duplicateConflictDroppedCount;
+
+  return { candles, stats };
+}
+
+export function shouldPostNormalizedBatch(
+  stats: NormalizationStats,
+  config: GeckoCollectorConfig
+): string | null {
+  if (stats.validCount === 0) return "zero_valid";
+  if (stats.providerRowCount > 0) {
+    const corruptionRate = stats.corruptionDroppedCount / stats.providerRowCount;
+    if (corruptionRate > 0.1) return "corruption_rate";
+  }
+  if (config.geckoLookback >= 50 && stats.validCount < 50) return "low_valid_count";
+  return null;
+}

--- a/src/workers/gecko/normalize.ts
+++ b/src/workers/gecko/normalize.ts
@@ -50,7 +50,7 @@ function parseRow(
       dropReason: "misaligned"
     };
 
-  if (o < 0 || h < 0 || l < 0 || c < 0 || v < 0) return null;
+  if (o <= 0 || h <= 0 || l <= 0 || c <= 0 || v < 0) return null;
 
   if (h < Math.max(o, c, l) || l > Math.min(o, c, h)) return null;
 

--- a/src/workers/gecko/retry.ts
+++ b/src/workers/gecko/retry.ts
@@ -76,9 +76,9 @@ export async function withRetry<T>(
 
       try {
         await sleep(delay);
-      } catch {
+      } catch (sleepErr: unknown) {
         if (signal?.aborted) throw err;
-        throw err;
+        throw sleepErr;
       }
     }
   }
@@ -105,7 +105,7 @@ export function createRateLimiter(
       if (currentTime < nextAllowedAt) {
         await sleep(nextAllowedAt - currentTime);
       }
-      nextAllowedAt = now() + intervalMs;
+      nextAllowedAt = Math.max(now(), nextAllowedAt) + intervalMs;
     }
   };
 }

--- a/src/workers/gecko/retry.ts
+++ b/src/workers/gecko/retry.ts
@@ -34,6 +34,26 @@ export function isRetryableHttpStatus(statusCode: number): boolean {
   return statusCode === 429 || statusCode >= 500;
 }
 
+function sleepWithAbortSignal(
+  ms: number,
+  signal: AbortSignal | undefined,
+  fallbackSleep: (ms: number) => Promise<void>
+): Promise<void> {
+  if (!signal) return fallbackSleep(ms);
+  return new Promise<void>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    const timer = setTimeout(resolve, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
 export type RetryDeps = {
   sleep?: (ms: number) => Promise<void>;
   now?: () => number;
@@ -75,7 +95,7 @@ export async function withRetry<T>(
       const delay = baseDelay + jitterMs(attempt);
 
       try {
-        await sleep(delay);
+        await sleepWithAbortSignal(delay, signal, sleep);
       } catch (sleepErr: unknown) {
         if (signal?.aborted) throw err;
         throw sleepErr;

--- a/src/workers/gecko/retry.ts
+++ b/src/workers/gecko/retry.ts
@@ -1,0 +1,111 @@
+export class HttpError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    public readonly responseBody: string,
+    public readonly retryable: boolean = isRetryableHttpStatus(statusCode)
+  ) {
+    super(`HTTP ${statusCode}`);
+    this.name = "HttpError";
+  }
+}
+
+export class ProtocolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProtocolError";
+  }
+}
+
+export class RequestTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RequestTimeoutError";
+  }
+}
+
+export class RequestTransportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RequestTransportError";
+  }
+}
+
+export function isRetryableHttpStatus(statusCode: number): boolean {
+  return statusCode === 429 || statusCode >= 500;
+}
+
+export type RetryDeps = {
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+  shouldContinue?: () => boolean;
+  signal?: AbortSignal;
+};
+
+export async function withRetry<T>(
+  operation: (attempt: number) => Promise<T>,
+  deps?: RetryDeps
+): Promise<T> {
+  const maxAttempts = 3;
+  const initialBackoffMs = 1000;
+  const maxBackoffMs = 30000;
+  const jitterMs = (attempt: number): number => attempt * 10;
+
+  const sleep = deps?.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const shouldContinue = deps?.shouldContinue ?? (() => true);
+  const signal = deps?.signal;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await operation(attempt);
+    } catch (err: unknown) {
+      if (err instanceof ProtocolError) throw err;
+      if (err instanceof HttpError && !err.retryable) throw err;
+      if (
+        !(err instanceof HttpError) &&
+        !(err instanceof RequestTimeoutError) &&
+        !(err instanceof RequestTransportError)
+      ) {
+        throw err;
+      }
+
+      if (attempt === maxAttempts) throw err;
+      if (!shouldContinue()) throw err;
+
+      const baseDelay = Math.min(initialBackoffMs * Math.pow(2, attempt - 1), maxBackoffMs);
+      const delay = baseDelay + jitterMs(attempt);
+
+      try {
+        await sleep(delay);
+      } catch {
+        if (signal?.aborted) throw err;
+        throw err;
+      }
+    }
+  }
+
+  throw new Error("withRetry: unreachable");
+}
+
+export type RateLimiter = {
+  waitForPermit(): Promise<void>;
+};
+
+export function createRateLimiter(
+  maxCallsPerMinute: number,
+  deps?: { sleep?: (ms: number) => Promise<void>; now?: () => number }
+): RateLimiter {
+  const intervalMs = 60_000 / maxCallsPerMinute;
+  const sleep = deps?.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const now = deps?.now ?? (() => Date.now());
+  let nextAllowedAt = 0;
+
+  return {
+    async waitForPermit() {
+      const currentTime = now();
+      if (currentTime < nextAllowedAt) {
+        await sleep(nextAllowedAt - currentTime);
+      }
+      nextAllowedAt = now() + intervalMs;
+    }
+  };
+}

--- a/src/workers/gecko/retry.ts
+++ b/src/workers/gecko/retry.ts
@@ -45,11 +45,14 @@ function sleepWithAbortSignal(
       reject(new DOMException("Aborted", "AbortError"));
       return;
     }
-    const timer = setTimeout(resolve, ms);
     const onAbort = () => {
       clearTimeout(timer);
       reject(new DOMException("Aborted", "AbortError"));
     };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
     signal.addEventListener("abort", onAbort, { once: true });
   });
 }

--- a/src/workers/geckoCollector.ts
+++ b/src/workers/geckoCollector.ts
@@ -1,0 +1,175 @@
+import { realpathSync } from "node:fs";
+import type { GeckoCollectorConfig } from "./gecko/config.js";
+import { parseGeckoCollectorConfig } from "./gecko/config.js";
+import type { WorkerLogger } from "./gecko/logger.js";
+import { consoleLogger } from "./gecko/logger.js";
+import { withRetry, createRateLimiter, type RetryDeps } from "./gecko/retry.js";
+import { normalizeGeckoOhlcv, shouldPostNormalizedBatch } from "./gecko/normalize.js";
+import { fetchGeckoOhlcv } from "./gecko/geckoClient.js";
+import { postCandles } from "./gecko/ingestClient.js";
+
+export function isMainModule(importMetaUrl: string, argvPath: string | undefined): boolean {
+  if (!argvPath) return false;
+  try {
+    const metaReal = realpathSync(new URL(importMetaUrl).pathname);
+    const argvReal = realpathSync(argvPath);
+    return metaReal === argvReal;
+  } catch {
+    return false;
+  }
+}
+
+export type GeckoCollectorDeps = {
+  fetchGeckoOhlcv?: (
+    config: GeckoCollectorConfig,
+    deps?: import("./gecko/geckoClient.js").GeckoClientDeps
+  ) => Promise<unknown>;
+  postCandles?: (
+    config: GeckoCollectorConfig,
+    candles: import("../contract/v1/types.js").Candle[],
+    sourceRecordedAtIso: string,
+    deps?: import("./gecko/ingestClient.js").IngestClientDeps
+  ) => Promise<import("../contract/v1/types.js").CandleIngestResponse>;
+  logger?: WorkerLogger;
+  nowIso?: () => string;
+  jitterMs?: (attempt: number) => number;
+  retrySignal?: AbortSignal;
+  shouldContinue?: () => boolean;
+  waitForProviderPermit?: () => Promise<void>;
+};
+
+export async function runOneCycle(
+  config: GeckoCollectorConfig,
+  deps?: GeckoCollectorDeps
+): Promise<void> {
+  const logger = deps?.logger ?? consoleLogger;
+  const nowIso = deps?.nowIso ?? (() => new Date().toISOString());
+  const shouldContinue = deps?.shouldContinue ?? (() => true);
+
+  logger.info("cycle_started");
+
+  const retryDeps: RetryDeps = {
+    signal: deps?.retrySignal,
+    shouldContinue: deps?.shouldContinue
+  };
+
+  let payload: unknown;
+  try {
+    payload = await withRetry(
+      (() =>
+        (deps?.fetchGeckoOhlcv ?? fetchGeckoOhlcv)(config, {
+          waitForProviderPermit: deps?.waitForProviderPermit
+        })) as (attempt: number) => Promise<unknown>,
+      retryDeps
+    );
+    logger.info("fetch_succeeded");
+  } catch (err: unknown) {
+    logger.error("fetch_failed", { error: err instanceof Error ? err.message : String(err) });
+    throw err;
+  }
+
+  if (!shouldContinue()) return;
+
+  const { candles, stats } = normalizeGeckoOhlcv(payload, config);
+  logger.info("normalized", {
+    validCount: stats.validCount,
+    totalDroppedCount: stats.totalDroppedCount
+  });
+
+  if (!shouldContinue()) return;
+
+  const guardReason = shouldPostNormalizedBatch(stats, config);
+  if (guardReason) {
+    logger.warn("batch_guarded", {
+      reason: guardReason,
+      validCount: stats.validCount,
+      providerRowCount: stats.providerRowCount
+    });
+    return;
+  }
+
+  const sourceRecordedAtIso = nowIso();
+  try {
+    const result = await withRetry(
+      () => (deps?.postCandles ?? postCandles)(config, candles, sourceRecordedAtIso),
+      retryDeps
+    );
+    logger.info("ingest_succeeded", {
+      insertedCount: result.insertedCount,
+      revisedCount: result.revisedCount,
+      idempotentCount: result.idempotentCount,
+      rejectedCount: result.rejectedCount
+    });
+  } catch (err: unknown) {
+    logger.error("ingest_failed", { error: err instanceof Error ? err.message : String(err) });
+    throw err;
+  }
+
+  logger.info("cycle_completed");
+}
+
+export async function runCollector(config?: GeckoCollectorConfig): Promise<void> {
+  const resolvedConfig = config ?? parseGeckoCollectorConfig(process.env);
+  const logger = consoleLogger;
+
+  const controller = new AbortController();
+  const shutdown = () => {
+    if (!controller.signal.aborted) {
+      controller.abort();
+      logger.info("shutdown_requested");
+    }
+  };
+
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+
+  const rateLimiter = createRateLimiter(resolvedConfig.geckoMaxCallsPerMinute);
+
+  try {
+    while (!controller.signal.aborted) {
+      try {
+        await runOneCycle(resolvedConfig, {
+          logger,
+          retrySignal: controller.signal,
+          shouldContinue: () => !controller.signal.aborted,
+          waitForProviderPermit: () => rateLimiter.waitForPermit()
+        });
+      } catch {
+        break;
+      }
+
+      if (controller.signal.aborted) break;
+
+      try {
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, resolvedConfig.geckoPollIntervalMs);
+          controller.signal.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              resolve();
+            },
+            { once: true }
+          );
+        });
+      } catch {
+        break;
+      }
+    }
+  } finally {
+    logger.info("shutdown_complete");
+  }
+}
+
+if (isMainModule(import.meta.url, process.argv[1])) {
+  runCollector().catch((err) => {
+    console.error(
+      JSON.stringify({
+        level: "fatal",
+        event: "collector_fatal",
+        error: err instanceof Error ? err.message : String(err)
+      })
+    );
+    process.exit(1);
+  });
+}

--- a/src/workers/geckoCollector.ts
+++ b/src/workers/geckoCollector.ts
@@ -8,6 +8,22 @@ import { normalizeGeckoOhlcv, shouldPostNormalizedBatch } from "./gecko/normaliz
 import { fetchGeckoOhlcv } from "./gecko/geckoClient.js";
 import { postCandles } from "./gecko/ingestClient.js";
 
+function sleepWithSignal(signal?: AbortSignal): (ms: number) => Promise<void> {
+  return (ms: number) =>
+    new Promise<void>((resolve, reject) => {
+      if (signal?.aborted) {
+        reject(new DOMException("Aborted", "AbortError"));
+        return;
+      }
+      const timer = setTimeout(resolve, ms);
+      const onAbort = () => {
+        clearTimeout(timer);
+        reject(new DOMException("Aborted", "AbortError"));
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
+}
+
 export function isMainModule(importMetaUrl: string, argvPath: string | undefined): boolean {
   if (!argvPath) return false;
   try {
@@ -121,10 +137,11 @@ export async function runCollector(
   const resolvedConfig = config ?? parseGeckoCollectorConfig(process.env);
   const logger = loopDeps?.logger ?? consoleLogger;
   const cycleFn = loopDeps?.runOneCycleFn ?? runOneCycle;
-  const sleepFn = loopDeps?.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
 
   const controller = new AbortController();
   const signal = loopDeps?.signal ?? controller.signal;
+  const defaultSleepFn = sleepWithSignal(signal);
+  const sleepFn = loopDeps?.sleep ?? defaultSleepFn;
   const shutdown = () => {
     if (!signal.aborted) {
       if (signal === controller.signal) {
@@ -139,8 +156,11 @@ export async function runCollector(
     process.on("SIGINT", shutdown);
   }
 
-  const rateLimiter = createRateLimiter(resolvedConfig.geckoMaxCallsPerMinute);
+  const rateLimiter = createRateLimiter(resolvedConfig.geckoMaxCallsPerMinute, {
+    sleep: (ms: number) => sleepFn(ms)
+  });
 
+  let cycleError: unknown;
   try {
     while (!signal.aborted) {
       try {
@@ -155,6 +175,7 @@ export async function runCollector(
         logger.error("cycle_error", {
           error: err instanceof Error ? err.message : String(err)
         });
+        cycleError = err;
         break;
       }
 
@@ -172,6 +193,10 @@ export async function runCollector(
       process.removeListener("SIGINT", shutdown);
     }
     logger.info("shutdown_complete");
+  }
+
+  if (cycleError !== undefined) {
+    throw cycleError;
   }
 }
 

--- a/src/workers/geckoCollector.ts
+++ b/src/workers/geckoCollector.ts
@@ -164,7 +164,6 @@ export async function runCollector(
     sleep: (ms: number) => sleepFn(ms)
   });
 
-  let cycleError: unknown;
   try {
     while (!signal.aborted) {
       try {
@@ -180,8 +179,6 @@ export async function runCollector(
         logger.error("cycle_error", {
           error: err instanceof Error ? err.message : String(err)
         });
-        cycleError = err;
-        break;
       }
 
       if (signal.aborted) break;
@@ -198,10 +195,6 @@ export async function runCollector(
       process.removeListener("SIGINT", shutdown);
     }
     logger.info("shutdown_complete");
-  }
-
-  if (cycleError !== undefined) {
-    throw cycleError;
   }
 }
 

--- a/src/workers/geckoCollector.ts
+++ b/src/workers/geckoCollector.ts
@@ -56,10 +56,10 @@ export async function runOneCycle(
   let payload: unknown;
   try {
     payload = await withRetry(
-      (() =>
+      () =>
         (deps?.fetchGeckoOhlcv ?? fetchGeckoOhlcv)(config, {
           waitForProviderPermit: deps?.waitForProviderPermit
-        })) as (attempt: number) => Promise<unknown>,
+        }),
       retryDeps
     );
     logger.info("fetch_succeeded");
@@ -108,55 +108,69 @@ export async function runOneCycle(
   logger.info("cycle_completed");
 }
 
-export async function runCollector(config?: GeckoCollectorConfig): Promise<void> {
+export type CollectorLoopDeps = GeckoCollectorDeps & {
+  signal?: AbortSignal;
+  runOneCycleFn?: (config: GeckoCollectorConfig, deps?: GeckoCollectorDeps) => Promise<void>;
+  sleep?: (ms: number) => Promise<void>;
+};
+
+export async function runCollector(
+  config?: GeckoCollectorConfig,
+  loopDeps?: CollectorLoopDeps
+): Promise<void> {
   const resolvedConfig = config ?? parseGeckoCollectorConfig(process.env);
-  const logger = consoleLogger;
+  const logger = loopDeps?.logger ?? consoleLogger;
+  const cycleFn = loopDeps?.runOneCycleFn ?? runOneCycle;
+  const sleepFn = loopDeps?.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
 
   const controller = new AbortController();
+  const signal = loopDeps?.signal ?? controller.signal;
   const shutdown = () => {
-    if (!controller.signal.aborted) {
-      controller.abort();
+    if (!signal.aborted) {
+      if (signal === controller.signal) {
+        controller.abort();
+      }
       logger.info("shutdown_requested");
     }
   };
 
-  process.on("SIGTERM", shutdown);
-  process.on("SIGINT", shutdown);
+  if (signal === controller.signal) {
+    process.on("SIGTERM", shutdown);
+    process.on("SIGINT", shutdown);
+  }
 
   const rateLimiter = createRateLimiter(resolvedConfig.geckoMaxCallsPerMinute);
 
   try {
-    while (!controller.signal.aborted) {
+    while (!signal.aborted) {
       try {
-        await runOneCycle(resolvedConfig, {
+        await cycleFn(resolvedConfig, {
+          ...loopDeps,
           logger,
-          retrySignal: controller.signal,
-          shouldContinue: () => !controller.signal.aborted,
+          retrySignal: signal,
+          shouldContinue: () => !signal.aborted,
           waitForProviderPermit: () => rateLimiter.waitForPermit()
         });
-      } catch {
+      } catch (err: unknown) {
+        logger.error("cycle_error", {
+          error: err instanceof Error ? err.message : String(err)
+        });
         break;
       }
 
-      if (controller.signal.aborted) break;
+      if (signal.aborted) break;
 
       try {
-        await new Promise<void>((resolve) => {
-          const timer = setTimeout(resolve, resolvedConfig.geckoPollIntervalMs);
-          controller.signal.addEventListener(
-            "abort",
-            () => {
-              clearTimeout(timer);
-              resolve();
-            },
-            { once: true }
-          );
-        });
+        await sleepFn(resolvedConfig.geckoPollIntervalMs);
       } catch {
         break;
       }
     }
   } finally {
+    if (signal === controller.signal) {
+      process.removeListener("SIGTERM", shutdown);
+      process.removeListener("SIGINT", shutdown);
+    }
     logger.info("shutdown_complete");
   }
 }

--- a/src/workers/geckoCollector.ts
+++ b/src/workers/geckoCollector.ts
@@ -176,6 +176,7 @@ export async function runCollector(
           waitForProviderPermit: () => rateLimiter.waitForPermit()
         });
       } catch (err: unknown) {
+        if (signal.aborted) break;
         logger.error("cycle_error", {
           error: err instanceof Error ? err.message : String(err)
         });

--- a/src/workers/geckoCollector.ts
+++ b/src/workers/geckoCollector.ts
@@ -56,6 +56,7 @@ export type GeckoCollectorDeps = {
   retrySignal?: AbortSignal;
   shouldContinue?: () => boolean;
   waitForProviderPermit?: () => Promise<void>;
+  shutdownSignal?: AbortSignal;
 };
 
 export async function runOneCycle(
@@ -78,7 +79,8 @@ export async function runOneCycle(
     payload = await withRetry(
       () =>
         (deps?.fetchGeckoOhlcv ?? fetchGeckoOhlcv)(config, {
-          waitForProviderPermit: deps?.waitForProviderPermit
+          waitForProviderPermit: deps?.waitForProviderPermit,
+          shutdownSignal: deps?.shutdownSignal
         }),
       retryDeps
     );
@@ -111,7 +113,10 @@ export async function runOneCycle(
   const sourceRecordedAtIso = nowIso();
   try {
     const result = await withRetry(
-      () => (deps?.postCandles ?? postCandles)(config, candles, sourceRecordedAtIso),
+      () =>
+        (deps?.postCandles ?? postCandles)(config, candles, sourceRecordedAtIso, {
+          shutdownSignal: deps?.shutdownSignal
+        }),
       retryDeps
     );
     logger.info("ingest_succeeded", {
@@ -172,7 +177,8 @@ export async function runCollector(
           logger,
           retrySignal: signal,
           shouldContinue: () => !signal.aborted,
-          waitForProviderPermit: () => rateLimiter.waitForPermit()
+          waitForProviderPermit: () => rateLimiter.waitForPermit(),
+          shutdownSignal: signal
         });
       } catch (err: unknown) {
         if (signal.aborted) break;

--- a/src/workers/geckoCollector.ts
+++ b/src/workers/geckoCollector.ts
@@ -1,4 +1,5 @@
 import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import type { GeckoCollectorConfig } from "./gecko/config.js";
 import { parseGeckoCollectorConfig } from "./gecko/config.js";
 import type { WorkerLogger } from "./gecko/logger.js";
@@ -30,7 +31,7 @@ function sleepWithSignal(signal?: AbortSignal): (ms: number) => Promise<void> {
 export function isMainModule(importMetaUrl: string, argvPath: string | undefined): boolean {
   if (!argvPath) return false;
   try {
-    const metaReal = realpathSync(new URL(importMetaUrl).pathname);
+    const metaReal = realpathSync(fileURLToPath(importMetaUrl));
     const argvReal = realpathSync(argvPath);
     return metaReal === argvReal;
   } catch {

--- a/src/workers/geckoCollector.ts
+++ b/src/workers/geckoCollector.ts
@@ -15,11 +15,14 @@ function sleepWithSignal(signal?: AbortSignal): (ms: number) => Promise<void> {
         reject(new DOMException("Aborted", "AbortError"));
         return;
       }
-      const timer = setTimeout(resolve, ms);
       const onAbort = () => {
         clearTimeout(timer);
         reject(new DOMException("Aborted", "AbortError"));
       };
+      const timer = setTimeout(() => {
+        signal?.removeEventListener("abort", onAbort);
+        resolve();
+      }, ms);
       signal?.addEventListener("abort", onAbort, { once: true });
     });
 }


### PR DESCRIPTION
## Summary

Adds a standalone GeckoTerminal candle collector worker that fetches SOL/USDC 1h OHLCV candles from GeckoTerminal's API, normalizes them, applies corruption guards, and posts to the regime-engine `/v1/candles` endpoint. The worker runs as a separate process alongside the main web service — no Fastify, SQLite, or Postgres imports.

## Key components

- **Config** (`config.ts`): Env-driven `GeckoCollectorConfig` with MVP validation, HTTPS enforcement, path rejection for `REGIME_ENGINE_URL`
- **Retry & rate limiting** (`retry.ts`): `withRetry` (3 attempts, exp backoff + jitter), `createRateLimiter` (anchored scheduling to prevent drift), error hierarchy (`HttpError`, `ProtocolError`, `RequestTimeoutError`, `RequestTransportError`)
- **Normalization** (`normalize.ts`): Validates GeckoTerminal envelope, converts Unix sec→ms, deduplicates, sorts, corruption guard (zero_valid, >10% corruption rate, low_valid_count)
- **HTTP clients** (`geckoClient.ts`, `ingestClient.ts`): Shared helpers in `httpUtils.ts` (`readTextWithLimit`, `parseJson`, `readErrorBody`), rate-limited fetch with timeout, 512KiB body cap, error response truncation
- **Collector loop** (`geckoCollector.ts`): Sequential fetch→normalize→guard→ingest cycle, SIGTERM/SIGINT graceful shutdown with handler cleanup, ESM entrypoint guard
- **Deployment**: Package scripts (`start`, `dev:gecko`, `start:gecko`), `.env.example`, README, Railway runbook for two-service deployment

## Architecture

```
GeckoTerminal API
       │
       ▼
┌──────────────────────────┐
│  geckoCollector worker    │
│  fetch → normalize →     │
│  guard → ingest          │
└──────────┬───────────────┘
           │ POST /v1/candles
           │ X-Candles-Ingest-Token
           ▼
┌──────────────────────────┐
│  regime-engine web        │
│  (Fastify + SQLite/PG)   │
└──────────────────────────┘
```

## Code review fixes (commit 2)

- Removed SIGTERM/SIGINT handler leak (`process.removeListener` in `finally`)
- Log cycle errors instead of silently swallowing
- Fixed rate limiter drift (`Math.max(now, nextAllowedAt) + interval`)
- Fixed retry sleep error propagation (abort→original error, non-abort→sleep error)
- Extracted shared HTTP helpers into `httpUtils.ts`
- Capped error response bodies at 1024 chars
- Added `REGIME_ENGINE_URL` path rejection in config validator
- Added `runCollector` loop tests and retry exhaustion test
- Replaced unsafe `as` type assertion with `() =>` arrow function

## Validation

```
pnpm run typecheck && pnpm run test && pnpm run lint && pnpm run build
# All pass. dist/src/workers/geckoCollector.js exists.
```

Closes #18 

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Claude_Code-GLM_5.1-D97757?logo=claude&logoColor=white)