### PR TITLE
m42: derived 1h candle aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,18 @@ Server endpoints:
   (`source + network + poolAddress + symbol + timeframe`). Append-only,
   per-slot decision tree (insert / idempotent / revise / reject). Token-guarded
   by `X-Candles-Ingest-Token` / `CANDLES_INGEST_TOKEN`.
-- `GET /v1/regime/current?symbol=&source=&network=&poolAddress=&timeframe=15m` —
-  market-only regime classification + CLMM suitability. Stateless: no
-  `RegimeState`, no portfolio/autopilot inputs, no plan-ledger writes.
+- `GET /v1/regime/current?symbol=&source=&network=&poolAddress=&timeframe=15m|1h` —
+  market-only regime classification + CLMM suitability. `timeframe=15m`
+  classifies stored 15m candles directly; `timeframe=1h` derives complete 1h
+  candles from stored 15m candles on the fly. Stateless: no `RegimeState`, no
+  portfolio/autopilot inputs, no plan-ledger writes.
 - `POST /v1/insights/sol-usdc` — CLMM insight ingestion (#20)
 - `GET /v1/insights/sol-usdc/current` — current CLMM insight
 - `GET /v1/insights/sol-usdc/history` — CLMM insight history
 - `POST /v2/sr-levels` — v2 S/R thesis ingestion (#21)
 - `GET /v2/sr-levels/current` — current v2 S/R thesis
 
-> **#41 contract change:** `POST /v1/candles` and `GET /v1/regime/current` accept `timeframe=15m` only. `timeframe=1h` is removed and is restored as a derived read in #42 (1h derived from stored 15m candles). Coordinate consumers before deploying.
+> **#41 / #42 contract:** `POST /v1/candles` accepts `timeframe=15m` only (provider ingestion is canonical at 15m). `GET /v1/regime/current` accepts `timeframe=15m | 1h`. The `1h` regime read is derived on the fly from stored 15m candles (no provider-ingested 1h candles, no derived storage). Response metadata includes `sourceTimeframe`, `sourceCandleCount`, and on derived reads `derivedTimeframe` and `aggregationVersion`.
 
 ## GeckoTerminal candle collector
 
@@ -63,19 +65,19 @@ pnpm run dev:gecko
 
 Worker env vars:
 
-| Variable                     | Default         | Notes                                                                     |
-| ---------------------------- | --------------- | ------------------------------------------------------------------------- |
-| `REGIME_ENGINE_URL`          | -               | Absolute URL for the regime-engine web service.                           |
-| `CANDLES_INGEST_TOKEN`       | -               | Shared secret sent as `X-Candles-Ingest-Token`; never commit real values. |
-| `GECKO_SOURCE`               | `geckoterminal` | Must equal `geckoterminal` for MVP.                                       |
-| `GECKO_NETWORK`              | `solana`        | Must equal `solana` for MVP.                                              |
-| `GECKO_POOL_ADDRESS`         | -               | Explicit GeckoTerminal SOL/USDC pool address. Confirm before production.  |
-| `GECKO_SYMBOL`               | `SOL/USDC`      | Must equal `SOL/USDC` for MVP.                                            |
-| `GECKO_TIMEFRAME`            | `15m`           | Must equal `15m`. (`1h` is removed in #41 until #42.)                     |
-| `GECKO_LOOKBACK`             | `200`           | Rolling candle window size.                                               |
-| `GECKO_POLL_INTERVAL_MS`     | `60000`         | Sleep after each completed cycle.                                         |
-| `GECKO_MAX_CALLS_PER_MINUTE` | `6`             | Provider-scoped GeckoTerminal call cap.                                   |
-| `GECKO_REQUEST_TIMEOUT_MS`   | `10000`         | Per-request timeout for provider and ingest calls.                        |
+| Variable                     | Default         | Notes                                                                                  |
+| ---------------------------- | --------------- | -------------------------------------------------------------------------------------- |
+| `REGIME_ENGINE_URL`          | -               | Absolute URL for the regime-engine web service.                                        |
+| `CANDLES_INGEST_TOKEN`       | -               | Shared secret sent as `X-Candles-Ingest-Token`; never commit real values.              |
+| `GECKO_SOURCE`               | `geckoterminal` | Must equal `geckoterminal` for MVP.                                                    |
+| `GECKO_NETWORK`              | `solana`        | Must equal `solana` for MVP.                                                           |
+| `GECKO_POOL_ADDRESS`         | -               | Explicit GeckoTerminal SOL/USDC pool address. Confirm before production.               |
+| `GECKO_SYMBOL`               | `SOL/USDC`      | Must equal `SOL/USDC` for MVP.                                                         |
+| `GECKO_TIMEFRAME`            | `15m`           | Must equal `15m`. Provider ingestion is canonical at 15m; 1h regime reads are derived. |
+| `GECKO_LOOKBACK`             | `200`           | Rolling candle window size.                                                            |
+| `GECKO_POLL_INTERVAL_MS`     | `60000`         | Sleep after each completed cycle.                                                      |
+| `GECKO_MAX_CALLS_PER_MINUTE` | `6`             | Provider-scoped GeckoTerminal call cap.                                                |
+| `GECKO_REQUEST_TIMEOUT_MS`   | `10000`         | Per-request timeout for provider and ingest calls.                                     |
 
 Railway services from the same repo (both use the same Dockerfile, selected via `SERVICE_TYPE`):
 

--- a/docs/solutions/best-practices/15m-candle-timeframe-migration-2026-05-06.md
+++ b/docs/solutions/best-practices/15m-candle-timeframe-migration-2026-05-06.md
@@ -311,4 +311,5 @@ if (timeframeMs === undefined) {
 - [Fastify SQLite Ingestion Endpoint Patterns](../best-practices/fastify-sqlite-ingestion-endpoint-patterns-2026-04-18.md) — auth, idempotency, and error taxonomy for ingestion endpoints. The timeframe allowlist pattern extends these validation patterns.
 - [TypeScript Strict Tooling Friction Patterns](../developer-experience/typescript-strict-tooling-friction-patterns-2026-05-01.md) — type guards for GeckoTerminal API payloads and test fixture alignment. Shares the gecko worker module.
 - GitHub #41 — "Switch Gecko candle ingestion and regime pipeline to 15m candles" (the milestone this migration completed)
-- GitHub #42 — "Add derived 1h candle aggregation from canonical 15m candles" (future work, referenced by `// until #42` comments)
+- [Derived Timeframe Aggregation Pattern](./derived-candle-aggregation-pattern-2026-05-06.md) — the m42 follow-up that implemented derived 1h reads by aggregating stored 15m candles at request time
+- GitHub #42 — "Add derived 1h candle aggregation from canonical 15m candles" (now implemented; see derived aggregation pattern)

--- a/docs/solutions/best-practices/15m-candle-timeframe-migration-2026-05-06.md
+++ b/docs/solutions/best-practices/15m-candle-timeframe-migration-2026-05-06.md
@@ -1,7 +1,7 @@
 ---
 title: 15m Candle Timeframe Migration Pattern
 date: 2026-05-06
-last_updated: 2026-05-06
+last_updated: 2026-05-07
 category: best-practices
 module: engine
 problem_type: best_practice
@@ -43,7 +43,7 @@ type SupportedTimeframe = "1h";
 
 // After: purpose-specific types that the compiler can track independently
 export type CandleIngestTimeframe = "15m";
-export type RegimeReadTimeframe = "15m";
+export type RegimeReadTimeframe = "15m" | "1h"; // widened in m42 for derived reads
 ```
 
 Then constrain each interface to its own type:
@@ -54,7 +54,7 @@ export interface CandleIngestRequest {
 }
 
 export interface RegimeCurrentResponse {
-  timeframe: RegimeReadTimeframe; // only accepts "15m" for read
+  timeframe: RegimeReadTimeframe; // "15m" for direct, "1h" for derived reads (m42)
 }
 ```
 
@@ -70,7 +70,7 @@ const SUPPORTED_TIMEFRAMES = ["1h"] as const;
 
 // After: separate allowlists per endpoint
 const CANDLE_INGEST_TIMEFRAMES = ["15m"] as const;
-const REGIME_READ_TIMEFRAMES = ["15m"] as const;
+const REGIME_READ_TIMEFRAMES = ["15m", "1h"] as const;
 
 const CANDLE_INGEST_TIMEFRAME_TO_MS: Record<CandleIngestTimeframe, number> = {
   "15m": 15 * 60 * 1000
@@ -85,11 +85,11 @@ const candleIngestRequestSchema = z.object({
 });
 
 const regimeCurrentQuerySchema = z.object({
-  timeframe: z.enum(REGIME_READ_TIMEFRAMES) // rejects "1h" with VALIDATION_ERROR
+  timeframe: z.enum(REGIME_READ_TIMEFRAMES) // accepts "15m" and "1h" (1h via derived aggregation)
 });
 ```
 
-Add a comment like `// until #42` at rejection points so future maintainers know the value is intentionally excluded, not accidentally omitted.
+Add a comment like `// until #<milestone>` at rejection points so future maintainers know the value is intentionally excluded, not accidentally omitted. Remove these comments once the milestone lands and the value is accepted.
 
 ### 3. Hard-reject unsupported timeframes in workers (no silent fallbacks)
 
@@ -182,10 +182,15 @@ Mitigation strategies:
 ```ts
 // Option A: Derive timeframeMs from the timeframe literal, so it cannot diverge
 const FIFTEEN_MIN_MS = 15 * 60 * 1000; // only one source of truth
-export const MARKET_REGIME_CONFIG: Record<"15m", MarketTimeframeConfig> = {
+export const MARKET_REGIME_CONFIG: Record<RegimeReadTimeframe, MarketTimeframeConfig> = {
   "15m": {
     timeframe: "15m",
     timeframeMs: FIFTEEN_MIN_MS
+    // ...
+  },
+  "1h": {
+    timeframe: "1h",
+    timeframeMs: ONE_HOUR_MS
     // ...
   }
 };
@@ -223,6 +228,8 @@ The type-safe migration pattern prevents partial updates. If you change `CandleI
 
 However, type narrowing cannot catch value-level errors where a constant name conveys the wrong semantics (see Section 7). Pair type-level enforcement with config sanity tests that assert specific millisecond values, especially when the unit of measurement changes.
 
+**Note (m42 update):** `RegimeReadTimeframe` has since been widened to `"15m" | "1h"` to support derived 1h reads. The candle-ingest path still only accepts `"15m"`. The handler now uses `buildRegimeCandleReadPlan` to compute read parameters and `aggregate15mTo1h` for derived aggregation — see [Derived Timeframe Aggregation Pattern](./derived-candle-aggregation-pattern-2026-05-06.md) for the current handler structure.
+
 ## When to Apply
 
 - Any timeframe or granularity change in a data pipeline where the old value appears in types, validation, URL construction, normalization, and documentation.
@@ -250,7 +257,7 @@ const SUPPORTED_TIMEFRAMES = ["1h"] as const;
 
 // validation.ts — After
 const CANDLE_INGEST_TIMEFRAMES = ["15m"] as const;
-const REGIME_READ_TIMEFRAMES = ["15m"] as const;
+const REGIME_READ_TIMEFRAMES = ["15m", "1h"] as const;
 
 const CANDLE_INGEST_TIMEFRAME_TO_MS: Record<CandleIngestTimeframe, number> = {
   "15m": 15 * 60 * 1000

--- a/docs/solutions/best-practices/derived-candle-aggregation-pattern-2026-05-06.md
+++ b/docs/solutions/best-practices/derived-candle-aggregation-pattern-2026-05-06.md
@@ -1,0 +1,173 @@
+---
+title: Derived Timeframe Aggregation Pattern
+date: 2026-05-06
+category: best-practices
+module: engine
+problem_type: best_practice
+component: service_object
+severity: low
+applies_when:
+  - Adding a derived timeframe that aggregates from stored source candles rather than ingesting separately
+  - Extending RegimeReadTimeframe with a new value that has no corresponding CandleIngestTimeframe
+  - Building a read-plan that decides between direct and derived candle sources based on config
+  - Deciding whether to persist aggregated candles or compute them at read time
+  - Adding metadata tracing fields to responses that serve derived data
+related_components:
+  - http
+  - engine/candles
+tags:
+  - candle-aggregation
+  - derived-timeframe
+  - read-plan
+  - regime-engine
+  - metadata-tracing
+  - ohlcv
+---
+
+# Derived Timeframe Aggregation Pattern
+
+## Context
+
+The regime-engine originally migrated from 1h to 15m candle ingestion (documented in [15m Candle Timeframe Migration](./15m-candle-timeframe-migration-2026-05-06.md)). Once 15m was the only stored timeframe, consumers that needed 1h regime signals had no way to get them without separately ingesting 1h candles — duplicating data pipelines and storage. The friction was: **how do you serve a coarser-grained view from a finer-grained source of truth, without duplicating ingest or storage?**
+
+The m41 migration had already split `CandleIngestTimeframe` (`"15m"` only) from `RegimeReadTimeframe` (`"15m" | "1h"`), but the `"1h"` option was a placeholder that validation rejected. Milestone m42 filled it in by aggregating 15m candles into 1h candles at read time.
+
+## Guidance
+
+### 1. Keep aggregation pure — no store access, no logging, no domain imports
+
+The `aggregateCandles` function takes `Candle[]` and a target timeframe, produces `Candle[]`. It has zero imports from the engine domain layer (`marketRegime/`) and no I/O. This makes it trivially testable, deterministic, and safe to call from any context:
+
+```ts
+// src/engine/candles/aggregateCandles.ts
+export const aggregateCandles = (
+  candles: Candle[],
+  target: AggregationTargetTimeframe
+): Candle[] => {
+  // Groups into buckets, validates alignment & completeness,
+  // derives OHLCV. Incomplete/misaligned buckets silently skipped.
+};
+```
+
+The aggregator enforces two integrity checks before emitting a derived candle: **exact count** (a 1h bucket must have exactly 4 source candles) and **sequential alignment** (timestamps must match `bucketOpen + i * sourceTimeframeMs`). Misaligned, incomplete, or non-integer timestamps are silently skipped — the handler decides whether to throw based on the result count.
+
+### 2. Compute all read parameters in a single plan function
+
+The handler should never compute cutoffs, limits, or metadata hints inline. A pure `buildRegimeCandleReadPlan` function produces everything the handler needs:
+
+```ts
+// src/engine/marketRegime/regimeCandleReadPlan.ts
+export const buildRegimeCandleReadPlan = (
+  input: BuildRegimeCandleReadPlanInput
+): RegimeCandleReadPlan => {
+  // For "15m" (direct): sourceCutoff, sourceLimit, DirectMetadataHints
+  // For "1h" (derived): sourceCutoff, sourceLimit (4x + buffer),
+  //                      derivedCutoff, DerivedMetadataHints
+};
+```
+
+The plan encodes:
+
+- **Source multiplier**: 1h needs 4× source candles, plus a buffer (`DERIVED_SOURCE_READ_BUFFER_15M = 32`) for alignment gaps.
+- **Dual cutoffs**: for derived timeframes, the plan computes both `sourceCutoffUnixMs` (source freshness) and `derivedCutoffUnixMs` (derived freshness). These differ because a source candle can be recent enough to read, but the derived candle it belongs to may still be incomplete (e.g., only 2 of 4 source bars available).
+- **Metadata hints**: `DirectMetadataHints` vs `DerivedMetadataHints` as a discriminated union so the handler can spread them into the response.
+
+Prefer narrowing on the plan's discriminated union (`plan.metadataHints.derivedTimeframe`) rather than checking `query.timeframe === "1h"` when branching, so the type system carries whether `derivedCutoffUnixMs` is present.
+
+### 3. Handler orchestrates; never computes domain logic
+
+```ts
+// src/http/handlers/regimeCurrent.ts
+const plan = buildRegimeCandleReadPlan({ requestedTimeframe, nowUnixMs });
+const sourceCandles = await readCandles(plan.sourceTimeframe, plan.sourceLimit, ...);
+
+let classifiedCandles = sourceCandles;
+if (query.timeframe === "1h") {
+  const aggregated = aggregateCandles(sourceCandles, "1h");
+  classifiedCandles = aggregated.filter(c => c.unixMs <= plan.derivedCutoffUnixMs!);
+  if (classifiedCandles.length === 0) {
+    throw candlesNotFoundError(/* derived-specific message */);
+  }
+}
+
+const response = buildRegimeCurrent({
+  metadata: { ...plan.metadataHints, sourceCandleCount: sourceCandles.length }
+});
+```
+
+No cutoff math, no limit multiplication, no metadata assembly in the handler.
+
+### 4. Make derivation transparent via metadata
+
+Callers must know whether data was aggregated. The response metadata exposes this:
+
+```ts
+// src/contract/v1/types.ts
+export interface RegimeCurrentMetadata {
+  engineVersion: string;
+  configVersion: string;
+  candleCount: number;
+  sourceTimeframe: "15m"; // always present — reveals physical store
+  sourceCandleCount: number; // how many 15m rows were read
+  derivedTimeframe?: "1h"; // present only when aggregation was applied
+  aggregationVersion?: "ohlcv-agg-v1"; // algorithm version for cache-busting
+}
+```
+
+The `metadataHints` from the plan spread directly into this shape — no handler-side branching needed for metadata construction.
+
+### 5. Use Record<UnionType, ...> to force exhaustive config
+
+When `"1h"` was added to `RegimeReadTimeframe`, the TypeScript compiler immediately flagged every file that accessed `MARKET_REGIME_CONFIG` — because it's typed as `Record<RegimeReadTimeframe, MarketTimeframeConfig>`. Add the union member first, let the compiler enumerate every missing implementation, then fill in the config entry.
+
+## Why This Matters
+
+- **Storage stays canonical** — only 15m candles are stored; 1h is a derived view, not a duplicate pipeline.
+- **Read-time derivation is observable** — metadata fields let callers reason about provenance; `aggregationVersion` enables cache-busting when the algorithm changes.
+- **The compiler enforces completeness** — `Record<RegimeReadTimeframe, ...>` forces every downstream lookup to handle new timeframes.
+- **Handler stays thin** — cutoffs, limits, multipliers, and metadata are all in the plan; the handler is a pure orchestrator.
+
+## Examples
+
+### Aggregation internals (bucket validation and OHLCV derivation)
+
+```ts
+const buckets = new Map<number, Candle[]>();
+for (const candle of candles) {
+  if (!Number.isInteger(candle.unixMs)) continue; // skip non-integer timestamps
+  if (candle.unixMs % srcMs !== 0) continue; // skip misaligned timestamps
+  const bucketOpen = Math.floor(candle.unixMs / bucketMs) * bucketMs;
+  // ... assign to bucket
+}
+
+for (const [bucketOpen, sources] of buckets) {
+  if (sources.length !== required) continue; // incomplete bucket → skip
+  sources.sort((a, b) => a.unixMs - b.unixMs);
+  let complete = true;
+  for (let i = 0; i < required; i += 1) {
+    if (sources[i].unixMs !== bucketOpen + i * srcMs) {
+      // sequential alignment check
+      complete = false;
+      break;
+    }
+  }
+  if (!complete) continue;
+
+  // Derive OHLCV from source candles
+  out.push({
+    unixMs: bucketOpen,
+    open: sources[0].open,
+    high: Math.max(...sources.map((s) => s.high)),
+    low: Math.min(...sources.map((s) => s.low)),
+    close: sources[required - 1].close,
+    volume: sources.reduce((sum, s) => sum + s.volume, 0)
+  });
+}
+```
+
+## Related
+
+- [15m Candle Timeframe Migration Pattern](./15m-candle-timeframe-migration-2026-05-06.md) — the m41 migration that established `CandleIngestTimeframe` vs `RegimeReadTimeframe`. This doc extends that pattern with read-time derivation.
+- [Market Regime Endpoint Patterns](./market-regime-endpoint-patterns-2026-04-27.md) — per-slot candle batch ingestion, timeframe-aware cutoff logic, stateless read-through pipeline.
+- GitHub #41 — "Switch Gecko candle ingestion and regime pipeline to 15m candles"
+- GitHub #42 — "Add derived 1h candle aggregation from canonical 15m candles"

--- a/docs/solutions/best-practices/market-regime-endpoint-patterns-2026-04-27.md
+++ b/docs/solutions/best-practices/market-regime-endpoint-patterns-2026-04-27.md
@@ -6,7 +6,7 @@ module: engine
 problem_type: best_practice
 component: service_object
 severity: low
-last_updated: "2026-05-06"
+last_updated: "2026-05-07"
 applies_when:
   - Adding candle ingestion endpoints with per-slot decision trees in SQLite
   - Building stateless regime classification read endpoints from raw ledger data
@@ -97,10 +97,14 @@ A candle is only eligible for regime computation if it's **closed** — enough t
 
 ```typescript
 // src/engine/marketRegime/closedCandleCutoff.ts
-function closedCandleCutoffUnixMs(asOfUnixMs: number, timeframe: Timeframe): number {
-  const timeframeMs = timeframe * 60 * 1000;
-  const GRACE_WINDOW_MS = 5 * 60 * 1000; // 5 minutes
-  return asOfUnixMs - timeframeMs - GRACE_WINDOW_MS;
+// Signature updated in m42 — now takes explicit params, not a Timeframe enum
+function closedCandleCutoffUnixMs(
+  nowUnixMs: number,
+  timeframeMs: number,
+  closedCandleDelayMs: number
+): number {
+  // Snaps to bar boundaries, then subtracts one full bar + grace delay
+  return Math.floor((nowUnixMs - closedCandleDelayMs) / timeframeMs) * timeframeMs - timeframeMs;
 }
 // A 15m candle at slot 14:00 is closed after 14:20 (one period + 5min grace)
 ```
@@ -109,47 +113,60 @@ Why a grace window instead of a strict boundary:
 
 - Candle providers often lag by 1-2 minutes
 - A strict `asOf - timeframeMs` would exclude candles that are complete but not yet ingested
-- 5 minutes gives enough slack for ingestion pipeline delays without letting truly half-formed data through
+- The `closedCandleDelayMs` parameter makes the grace window configurable per timeframe
 
 ### 3. Freshness Classification from Candle Age
 
-Once you know which candles are closed, classify how fresh the latest one is:
+Once you know which candles are closed, classify how fresh the latest one is. Freshness is now a structured result with boolean flags and numeric thresholds, configurable per timeframe:
 
 ```typescript
 // src/engine/marketRegime/freshness.ts
-type Freshness = "fresh" | "soft-stale" | "hard-stale";
-
+// Returns a FreshnessResult object with softStale/hardStale booleans and numeric fields
+// Thresholds come from MARKET_REGIME_CONFIG[timeframe].freshness
 function computeFreshness(
   latestClosedUnixMs: number,
-  asOfUnixMs: number,
-  timeframe: Timeframe
-): Freshness {
-  const ageMs = asOfUnixMs - latestClosedUnixMs;
-  const timeframeMs = timeframe * 60 * 1000;
-
-  if (ageMs < 2 * timeframeMs) return "fresh"; // < 30m for 15m
-  if (ageMs < 4 * timeframeMs) return "soft-stale"; // 30m-1h for 15m
-  return "hard-stale"; // > 1h for 15m
+  nowUnixMs: number,
+  freshnessConfig: FreshnessConfig
+): FreshnessResult {
+  // softStale: age exceeds soft threshold
+  // hardStale: age exceeds hard threshold
+  // Also provides ageSeconds, softStaleSeconds, hardStaleSeconds for telemetry
 }
 ```
 
 This is a **pure function** — no state, no DB, no side effects. It feeds directly into suitability scoring.
 
+**Note (m42):** For derived 1h reads, the handler uses `buildRegimeCandleReadPlan` which computes separate cutoffs for source (15m) and derived (1h) timeframes. The freshness classification uses the derived timeframe's thresholds when aggregation is applied.
+
 ### 4. Four-Band CLMM Suitability with Band Precedence
 
-Suitability uses a precedence-ordered four-band model. The highest-severity band wins, and reasons accumulate **only within the winning band**.
+Suitability uses precedence-ordered bands. The highest-severity band wins. The implementation uses early-return logic rather than a band array:
 
 ```typescript
 // src/engine/marketRegime/evaluateMarketClmmSuitability.ts
-type SuitabilityBand = "ALLOWED" | "CAUTION" | "BLOCKED" | "UNKNOWN";
-const BAND_PRECEDENCE: SuitabilityBand[] = ["UNKNOWN", "BLOCKED", "CAUTION", "ALLOWED"];
+// Semantics: UNKNOWN > BLOCKED > CAUTION > ALLOWED
+// Implementation: early returns check minCandles/hardStale first, then blocks, then cautions
 
-// Each condition pushes a reason into the appropriate band
-// Then the first non-empty band in precedence order wins
-for (const band of BAND_PRECEDENCE) {
-  if (bands[band].length > 0) {
-    return { band, reasons: bands[band] };
-  }
+function evaluateMarketClmmSuitability(
+  regime: MarketRegime,
+  freshnessResult: FreshnessResult,
+  candleCount: number,
+  config: FreshnessConfig
+): ClmmSuitability {
+  // UNKNOWN: insufficient data (too few candles or hard-stale data)
+  if (candleCount < config.minCandles) return { band: "UNKNOWN", reasons: [...] };
+  if (freshnessResult.hardStale) return { band: "UNKNOWN", reasons: [...] };
+
+  // BLOCKED: regime conditions make CLMM unsafe
+  const blockedReasons = [...];
+  if (blockedReasons.length > 0) return { band: "BLOCKED", reasons: blockedReasons };
+
+  // CAUTION: data quality concerns but regime allows
+  const cautionReasons = [...];
+  if (cautionReasons.length > 0) return { band: "CAUTION", reasons: cautionReasons };
+
+  // ALLOWED: all clear
+  return { band: "ALLOWED", reasons: [...] };
 }
 ```
 
@@ -160,10 +177,11 @@ Critical design rule: **a single `BLOCKED` reason makes the entire result `BLOCK
 The `/v1/regime/current` endpoint computes everything from raw candle data on every request. No regime state is persisted. The pipeline is:
 
 ```
-parseQuery → getLatestCandlesForFeed → closedCandleCutoff → freshness
-           → computeIndicators → classifyMarketRegime → evaluateClmmSuitability
-           → response
+parseRegimeCurrentQuery → buildRegimeCandleReadPlan → getLatestCandlesForFeed
+  → [aggregate15mTo1h if derived] → buildRegimeCurrent → response
 ```
+
+`buildRegimeCandleReadPlan` replaces the handler-level cutoff and limit computation. It produces a `RegimeCandleReadPlan` (discriminated union: `direct` or `derived` mode) with all read parameters: source cutoff, source limit, derived cutoff (if applicable), and source metadata. For derived 1h reads, the handler aggregates 15m candles into 1h buckets before passing them to `buildRegimeCurrent`. See [Derived Timeframe Aggregation Pattern](./derived-candle-aggregation-pattern-2026-05-06.md).
 
 This pattern trades compute cost for correctness guarantees:
 
@@ -176,20 +194,22 @@ The trade-off: every request does a DB read + indicator computation. For a micro
 
 ### 6. Market-Only Classification is Deliberately Simplified
 
-`classifyMarketRegime` wraps `classifyRegime` with locked parameters:
+`classifyMarketRegime` wraps `classifyRegime` with config-driven parameters:
 
 ```typescript
 // src/engine/marketRegime/classifyMarketRegime.ts
-function classifyMarketRegime(indicators: Indicators, config: MarketRegimeConfig): Regime {
-  return classifyRegime(indicators, {
-    state: undefined, // always stateless — no hysteresis carryover
-    confirmBars: 1, // immediate classification
-    minHoldBars: 0 // no minimum hold — market regime can flip on next call
-  });
+function classifyMarketRegime(
+  telemetry: IndicatorTelemetry,
+  config: MarketTimeframeConfig["regime"]
+): Regime {
+  // Loops classifyRegime for config.confirmBars iterations
+  // 15m config: confirmBars=2 (one confirmation bar required)
+  // 1h config: confirmBars=1 (immediate classification)
+  // minHoldBars=0 for both — market regime can flip on next call
 }
 ```
 
-This deliberately disables two features of the full classifier:
+This deliberately provides some confirmation for 15m (confirmBars=2) while keeping 1h immediate (confirmBars=1), but disables portfolio-level hysteresis for both:
 
 - `confirmBars: 1` means **no REGIME_CONFIRM_PENDING** — the market regime is always resolved
 - `minHoldBars: 0` means **no REGIME_MIN_HOLD_ACTIVE** — the market regime can flip freely
@@ -252,10 +272,13 @@ Full pipeline with autopilot state, hysteresis, and plan ledger writes. No way t
 
 ```typescript
 // GET /v1/regime/current?symbol=SOL&source=coingecko&network=mainnet&poolAddress=...&timeframe=15m
+// GET /v1/regime/current?symbol=SOL&source=coingecko&network=mainnet&poolAddress=...&timeframe=1h
 // No auth, no ledger writes, stateless computation
 const query = parseRegimeCurrentQuery(request.query);
-const candles = getLatestCandlesForFeed(store, query);
-const regimeCurrent = buildRegimeCurrent(candles, query.asOf);
+const plan = buildRegimeCandleReadPlan({ requestedTimeframe: query.timeframe, nowUnixMs });
+// Read 15m candles always (1h derives from them at read time)
+const candles = await getLatestCandlesForFeed(store, { ...query, ...plan });
+const regimeCurrent = buildRegimeCurrent({ candles, metadata: { ...plan.sourceMetadata, sourceCandleCount: candles.length }, ... });
 ```
 
 ### Four-band suitability in practice
@@ -280,8 +303,8 @@ Input: regime=UP, freshness=soft-stale
 - [Fastify+SQLite Ingestion Endpoint Patterns](./fastify-sqlite-ingestion-endpoint-patterns-2026-04-18.md) — Shared auth, idempotency, and transaction patterns that the candle endpoint follows
 - [Regime-engine Deploy Docs Gap](../documentation-gaps/regime-engine-deploy-docs-smoke-tests-runbook-2026-04-19.md) — Deploy readiness and operational verification for the full API surface including these new endpoints
 - `src/engine/marketRegime/config.ts` — Committed per-timeframe config (15m primary; 1h derived via aggregation, see [Derived Timeframe Aggregation Pattern](./derived-candle-aggregation-pattern-2026-05-06.md))
-- `src/engine/candles/aggregateCandles.ts` — Pure OHLCV aggregation utility for derived timeframes
-- `src/engine/marketRegime/regimeCandleReadPlan.ts` — Read-plan abstraction for direct vs derived candle reads
+- `src/engine/candles/aggregateCandles.ts` — Pure OHLCV 15m→1h aggregation utility with telemetry
+- `src/engine/marketRegime/regimeCandleReadPlan.ts` — Read-plan abstraction (discriminated union: direct vs derived)
 - `src/ledger/candlesWriter.ts` — Per-slot decision tree + `BEGIN IMMEDIATE`
 - `src/engine/marketRegime/evaluateMarketClmmSuitability.ts` — Four-band decision tree
 - GitHub #17 — "Add market-data-backed current regime endpoint for CLMM Regime page"

--- a/docs/solutions/best-practices/market-regime-endpoint-patterns-2026-04-27.md
+++ b/docs/solutions/best-practices/market-regime-endpoint-patterns-2026-04-27.md
@@ -279,7 +279,9 @@ Input: regime=UP, freshness=soft-stale
 
 - [Fastify+SQLite Ingestion Endpoint Patterns](./fastify-sqlite-ingestion-endpoint-patterns-2026-04-18.md) — Shared auth, idempotency, and transaction patterns that the candle endpoint follows
 - [Regime-engine Deploy Docs Gap](../documentation-gaps/regime-engine-deploy-docs-smoke-tests-runbook-2026-04-19.md) — Deploy readiness and operational verification for the full API surface including these new endpoints
-- `src/engine/marketRegime/config.ts` — Committed per-timeframe config (15m primary; 1h derived planned in #42)
+- `src/engine/marketRegime/config.ts` — Committed per-timeframe config (15m primary; 1h derived via aggregation, see [Derived Timeframe Aggregation Pattern](./derived-candle-aggregation-pattern-2026-05-06.md))
+- `src/engine/candles/aggregateCandles.ts` — Pure OHLCV aggregation utility for derived timeframes
+- `src/engine/marketRegime/regimeCandleReadPlan.ts` — Read-plan abstraction for direct vs derived candle reads
 - `src/ledger/candlesWriter.ts` — Per-slot decision tree + `BEGIN IMMEDIATE`
 - `src/engine/marketRegime/evaluateMarketClmmSuitability.ts` — Four-band decision tree
 - GitHub #17 — "Add market-data-backed current regime endpoint for CLMM Regime page"

--- a/docs/superpowers/plans/2026-05-06-derived-1h-candle-aggregation.md
+++ b/docs/superpowers/plans/2026-05-06-derived-1h-candle-aggregation.md
@@ -1,0 +1,1897 @@
+# Derived 1h Candle Aggregation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow `GET /v1/regime/current?timeframe=1h` to return a market regime classified on derived `1h` candles aggregated on-the-fly from stored `15m` candles, while keeping `POST /v1/candles` restricted to `15m` provider candles. The direct `15m` regime read remains for diagnostics.
+
+**Architecture:** Add a pure aggregation utility (`aggregateCandles`) and a small read-policy helper (`regimeCandleReadPlan`). The handler orchestrates: select `MARKET_REGIME_CONFIG[requested]`, build a read plan, read latest-revision `15m` rows from the existing store, and either (a) classify the `15m` rows directly, or (b) aggregate them into complete `1h` buckets, filter by the `1h` derived cutoff, and classify those. `buildRegimeCurrent` stays source-agnostic — the handler injects metadata fields (`sourceTimeframe`, `sourceCandleCount`, optional `derivedTimeframe`, `aggregationVersion`). No new database storage; no provider `1h` ingestion.
+
+**Tech Stack:** TypeScript (Node 22, ESM, NodeNext resolution), Fastify, Zod, vitest, Drizzle (Postgres), better-sqlite3 (SQLite). pnpm workspace; tests run via `pnpm test`.
+
+---
+
+## Pre-flight
+
+- [ ] **Step 0: Confirm a clean working tree on a fresh branch from `main`**
+
+Run:
+
+```bash
+git status
+git log -1 --oneline
+git checkout -b m42-derived-1h-aggregation
+```
+
+Expected: working tree clean (or only this plan file unstaged), HEAD on `d391880 m42: add derived 1h aggregation design`. The design commit on `main` is what this plan implements.
+
+- [ ] **Step 1: Run the existing test suite to confirm a green baseline**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected: all tests pass on the current `15m`-only codebase. If any are red, stop and surface the failure before changing anything.
+
+- [ ] **Step 2: Run typecheck and lint to confirm a green baseline**
+
+Run:
+
+```bash
+pnpm typecheck && pnpm lint
+```
+
+Expected: both succeed with zero errors / zero warnings.
+
+---
+
+## File Map
+
+Files created:
+
+- `src/engine/candles/aggregateCandles.ts` — pure aggregation utility; aggregates `15m` source candles into complete `1h` derived candles.
+- `src/engine/candles/__tests__/aggregateCandles.test.ts` — unit tests for the aggregation utility.
+- `src/engine/marketRegime/regimeCandleReadPlan.ts` — pure helper that returns source timeframe, source/derived cutoffs, source limit, and direct/derived metadata hints for a regime-read timeframe.
+- `src/engine/marketRegime/__tests__/regimeCandleReadPlan.test.ts` — unit tests for the read-plan helper.
+
+Files modified:
+
+- `src/contract/v1/types.ts` — widen `RegimeReadTimeframe` to `"15m" | "1h"`; extend `RegimeCurrentMetadata` with `sourceTimeframe`, `sourceCandleCount`, optional `derivedTimeframe`, optional `aggregationVersion`.
+- `src/contract/v1/validation.ts` — add `"1h"` to `REGIME_READ_TIMEFRAMES`; widen the return type of `parseRegimeCurrentQuery`. `CANDLE_INGEST_TIMEFRAMES` is unchanged.
+- `src/contract/v1/__tests__/regimeCurrent.validation.test.ts` — replace the "rejects timeframe=1h until #42" test with one that accepts `"1h"`; keep an unsupported-timeframe rejection test.
+- `src/engine/marketRegime/config.ts` — change `MarketTimeframeConfig.timeframe` to `RegimeReadTimeframe`; change `MARKET_REGIME_CONFIG` to `Record<RegimeReadTimeframe, MarketTimeframeConfig>`; restore the `"1h"` entry alongside the existing `"15m"` entry.
+- `src/engine/marketRegime/__tests__/config.test.ts` — add coverage for the restored `"1h"` entry.
+- `src/engine/marketRegime/buildRegimeCurrent.ts` — accept optional caller-supplied metadata fields and merge them into `metadata`. No source/derived decisions inside.
+- `src/engine/marketRegime/__tests__/buildRegimeCurrent.test.ts` — add a test asserting that supplied metadata fields are reflected in the response.
+- `src/engine/marketRegime/__tests__/buildRegimeCurrent.snapshot.test.ts` — pass new `sourceTimeframe`/`sourceCandleCount` from caller; regenerate snapshot.
+- `src/http/handlers/regimeCurrent.ts` — orchestrate direct vs derived flow using `regimeCandleReadPlan` and `aggregateCandles`; supply metadata fields to `buildRegimeCurrent`.
+- `src/http/__tests__/regimeCurrent.e2e.test.ts` — keep existing direct `15m` tests; add direct `15m` metadata assertions; add derived `1h` end-to-end tests (success, incomplete-current-bucket exclusion, zero-candles-after-filter, insufficient-samples passthrough).
+- `src/http/openapi.ts` — `/v1/regime/current` `timeframe` enum becomes `["15m", "1h"]`; refresh summary text.
+- `README.md` — refresh the `#41/#42` note: `1h` regime read is restored as a derived read.
+
+Files **not** changed:
+
+- `src/contract/v1/__tests__/candles.validation.test.ts` (still rejects `1h` ingestion — no change needed; the existing test is correct on its own terms).
+- `src/contract/v1/__tests__/validation.test.ts` (the `PlanRequest.market.timeframe` is typed `string`, unrelated to regime-read).
+- `src/ledger/store.ts`, `src/ledger/candlesWriter.ts`, `src/ledger/candleStore.ts`, Drizzle/SQLite schemas — no derived candle storage.
+- `src/engine/marketRegime/closedCandleCutoff.ts`, `src/engine/marketRegime/freshness.ts` — pure functions of input config, unchanged.
+- `src/workers/gecko/*` — provider ingestion remains `15m` only; out of scope.
+
+---
+
+## Task Sequencing
+
+The aggregation utility and the read-plan helper are independent of each other (they can land in parallel). The handler refactor depends on both, on the widened types (`RegimeReadTimeframe`), on the validator change, on the config change (`MARKET_REGIME_CONFIG["1h"]`), and on the `buildRegimeCurrent` metadata extension. Land tasks in the order below; do not jump ahead.
+
+1. Widen types (`RegimeReadTimeframe`, `RegimeCurrentMetadata`).
+2. Widen the validator allowlist for regime read.
+3. Restore the `1h` entry in `MARKET_REGIME_CONFIG`.
+4. Add `aggregateCandles` (TDD).
+5. Add `regimeCandleReadPlan` (TDD).
+6. Extend `buildRegimeCurrent` with caller-supplied metadata.
+7. Rewrite the regime-current handler.
+8. Add/update e2e tests.
+9. Update OpenAPI and README.
+10. Run the quality gate.
+
+---
+
+### Task 1: Widen `RegimeReadTimeframe` and extend `RegimeCurrentMetadata`
+
+**Files:**
+
+- Modify: `src/contract/v1/types.ts:225-310`
+
+- [ ] **Step 1: Edit `src/contract/v1/types.ts` to widen `RegimeReadTimeframe`**
+
+Find:
+
+```ts
+export type CandleIngestTimeframe = "15m";
+export type RegimeReadTimeframe = "15m";
+```
+
+Replace with:
+
+```ts
+export type CandleIngestTimeframe = "15m";
+export type RegimeReadTimeframe = "15m" | "1h";
+```
+
+`CandleIngestTimeframe` stays narrow.
+
+- [ ] **Step 2: Extend `RegimeCurrentMetadata` with source/derived fields**
+
+Find:
+
+```ts
+export interface RegimeCurrentMetadata {
+  engineVersion: string;
+  configVersion: string;
+  candleCount: number;
+}
+```
+
+Replace with:
+
+```ts
+export interface RegimeCurrentMetadata {
+  engineVersion: string;
+  configVersion: string;
+  candleCount: number;
+  sourceTimeframe: "15m";
+  sourceCandleCount: number;
+  derivedTimeframe?: "1h";
+  aggregationVersion?: "ohlcv-agg-v1";
+}
+```
+
+The four new fields are mandatory in shape: `sourceTimeframe` and `sourceCandleCount` are always present; `derivedTimeframe` and `aggregationVersion` are present only on derived reads.
+
+- [ ] **Step 3: Run typecheck to surface every call site that constructs metadata**
+
+Run:
+
+```bash
+pnpm typecheck
+```
+
+Expected: typecheck FAILS with errors in `src/engine/marketRegime/buildRegimeCurrent.ts` (missing `sourceTimeframe` / `sourceCandleCount`) and possibly in tests that build a full `RegimeCurrentResponse` literal. This is the intended state — those will be fixed in later tasks. Note the failing files; you'll revisit them.
+
+- [ ] **Step 4: Commit the type changes**
+
+```bash
+git add src/contract/v1/types.ts
+git commit -m "m42: widen RegimeReadTimeframe and extend RegimeCurrentMetadata"
+```
+
+---
+
+### Task 2: Accept `1h` in `parseRegimeCurrentQuery`
+
+**Files:**
+
+- Modify: `src/contract/v1/validation.ts:280-435`
+- Test: `src/contract/v1/__tests__/regimeCurrent.validation.test.ts`
+
+- [ ] **Step 1: Update the regime-read validation test (replace the 1h-rejection case)**
+
+Open `src/contract/v1/__tests__/regimeCurrent.validation.test.ts`.
+
+Find:
+
+```ts
+it("rejects timeframe=1h until #42", () => {
+  expect.assertions(1);
+  try {
+    parseRegimeCurrentQuery({ ...baseQuery, timeframe: "1h" });
+  } catch (error) {
+    expect((error as ContractValidationError).response.error.code).toBe("VALIDATION_ERROR");
+  }
+});
+```
+
+Replace with:
+
+```ts
+it("accepts timeframe=15m", () => {
+  const result = parseRegimeCurrentQuery({ ...baseQuery, timeframe: "15m" });
+  expect(result.timeframe).toBe("15m");
+});
+
+it("accepts timeframe=1h", () => {
+  const result = parseRegimeCurrentQuery({ ...baseQuery, timeframe: "1h" });
+  expect(result.timeframe).toBe("1h");
+});
+
+it("rejects unsupported regime-read timeframe (e.g. 4h) with VALIDATION_ERROR", () => {
+  expect.assertions(1);
+  try {
+    parseRegimeCurrentQuery({ ...baseQuery, timeframe: "4h" });
+  } catch (error) {
+    expect((error as ContractValidationError).response.error.code).toBe("VALIDATION_ERROR");
+  }
+});
+```
+
+- [ ] **Step 2: Run the test to confirm `"1h"` is currently rejected**
+
+Run:
+
+```bash
+pnpm test -- src/contract/v1/__tests__/regimeCurrent.validation.test.ts
+```
+
+Expected: the new "accepts timeframe=1h" test FAILS because the current `REGIME_READ_TIMEFRAMES` allowlist excludes `"1h"`.
+
+- [ ] **Step 3: Widen `REGIME_READ_TIMEFRAMES` and the validator return type**
+
+Open `src/contract/v1/validation.ts`.
+
+Find:
+
+```ts
+const CANDLE_INGEST_TIMEFRAMES = ["15m"] as const;
+const REGIME_READ_TIMEFRAMES = ["15m"] as const;
+```
+
+Replace with:
+
+```ts
+const CANDLE_INGEST_TIMEFRAMES = ["15m"] as const;
+const REGIME_READ_TIMEFRAMES = ["15m", "1h"] as const;
+```
+
+Then find:
+
+```ts
+export const parseRegimeCurrentQuery = (
+  raw: unknown
+): {
+  symbol: string;
+  source: string;
+  network: string;
+  poolAddress: string;
+  timeframe: "15m";
+} => {
+```
+
+Replace with:
+
+```ts
+import type { RegimeReadTimeframe } from "./types.js";
+
+// (Keep this import grouped with the other type imports at the top of the file.)
+
+export const parseRegimeCurrentQuery = (
+  raw: unknown
+): {
+  symbol: string;
+  source: string;
+  network: string;
+  poolAddress: string;
+  timeframe: RegimeReadTimeframe;
+} => {
+```
+
+(If `RegimeReadTimeframe` is not already imported in this file, add it to the existing import-from-`./types.js` block at the top rather than introducing a duplicate import.)
+
+- [ ] **Step 4: Run the validation test to confirm it passes**
+
+Run:
+
+```bash
+pnpm test -- src/contract/v1/__tests__/regimeCurrent.validation.test.ts
+```
+
+Expected: PASS for the three new assertions plus the existing "accepts the five required selectors" test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/contract/v1/validation.ts src/contract/v1/__tests__/regimeCurrent.validation.test.ts
+git commit -m "m42: accept timeframe=1h on /v1/regime/current"
+```
+
+---
+
+### Task 3: Restore the `1h` entry in `MARKET_REGIME_CONFIG`
+
+**Files:**
+
+- Modify: `src/engine/marketRegime/config.ts`
+- Test: `src/engine/marketRegime/__tests__/config.test.ts`
+
+- [ ] **Step 1: Add a failing test for the restored 1h config**
+
+Open `src/engine/marketRegime/__tests__/config.test.ts`.
+
+Append a new `describe` block at the end of the file:
+
+```ts
+describe("MARKET_REGIME_CONFIG[1h]", () => {
+  it("has timeframeMs equal to 1 hour", () => {
+    expect(MARKET_REGIME_CONFIG["1h"].timeframeMs).toBe(60 * 60 * 1000);
+  });
+
+  it("has the original 1h indicator and regime windows", () => {
+    const config = MARKET_REGIME_CONFIG["1h"];
+    expect(config.indicators.volShortWindow).toBe(8);
+    expect(config.indicators.volLongWindow).toBe(21);
+    expect(config.indicators.trendWindow).toBe(14);
+    expect(config.indicators.compressionWindow).toBe(20);
+    expect(config.regime.confirmBars).toBe(1);
+    expect(config.suitability.minCandles).toBe(30);
+  });
+
+  it("has the original 1h freshness thresholds", () => {
+    const config = MARKET_REGIME_CONFIG["1h"];
+    expect(config.freshness.closedCandleDelayMs).toBe(5 * 60 * 1000);
+    expect(config.freshness.softStaleMs).toBe(75 * 60 * 1000);
+    expect(config.freshness.hardStaleMs).toBe(90 * 60 * 1000);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+Run:
+
+```bash
+pnpm test -- src/engine/marketRegime/__tests__/config.test.ts
+```
+
+Expected: the new tests FAIL because `MARKET_REGIME_CONFIG["1h"]` does not exist.
+
+- [ ] **Step 3: Update `MarketTimeframeConfig.timeframe` and add the `1h` entry**
+
+Open `src/engine/marketRegime/config.ts`.
+
+Replace the entire file contents with:
+
+```ts
+import type { RegimeReadTimeframe } from "../../contract/v1/types.js";
+
+export const MARKET_REGIME_CONFIG_VERSION = "market-regime-2.0.0" as const;
+
+export interface MarketTimeframeConfig {
+  timeframe: RegimeReadTimeframe;
+  timeframeMs: number;
+  indicators: {
+    volShortWindow: number;
+    volLongWindow: number;
+    trendWindow: number;
+    compressionWindow: number;
+  };
+  regime: {
+    confirmBars: number;
+    minHoldBars: number;
+    enterUpTrend: number;
+    exitUpTrend: number;
+    enterDownTrend: number;
+    exitDownTrend: number;
+    chopVolRatioMax: number;
+  };
+  suitability: {
+    allowedVolRatioMax: number;
+    extremeVolRatio: number;
+    extremeCompression: number;
+    minCandles: number;
+  };
+  freshness: {
+    closedCandleDelayMs: number;
+    softStaleMs: number;
+    hardStaleMs: number;
+  };
+}
+
+const FIFTEEN_MIN_MS = 15 * 60 * 1000;
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+export const MARKET_REGIME_CONFIG: Record<RegimeReadTimeframe, MarketTimeframeConfig> = {
+  "15m": {
+    timeframe: "15m",
+    timeframeMs: FIFTEEN_MIN_MS,
+    indicators: {
+      volShortWindow: 32,
+      volLongWindow: 84,
+      trendWindow: 56,
+      compressionWindow: 80
+    },
+    regime: {
+      confirmBars: 2,
+      minHoldBars: 0,
+      enterUpTrend: 0.6,
+      exitUpTrend: 0.35,
+      enterDownTrend: -0.6,
+      exitDownTrend: -0.35,
+      chopVolRatioMax: 1.4
+    },
+    suitability: {
+      allowedVolRatioMax: 1.3,
+      extremeVolRatio: 1.6,
+      extremeCompression: 0.18,
+      minCandles: 120
+    },
+    freshness: {
+      closedCandleDelayMs: 2 * 60 * 1000,
+      softStaleMs: 25 * 60 * 1000,
+      hardStaleMs: 35 * 60 * 1000
+    }
+  },
+  "1h": {
+    timeframe: "1h",
+    timeframeMs: ONE_HOUR_MS,
+    indicators: {
+      volShortWindow: 8,
+      volLongWindow: 21,
+      trendWindow: 14,
+      compressionWindow: 20
+    },
+    regime: {
+      confirmBars: 1,
+      minHoldBars: 0,
+      enterUpTrend: 0.6,
+      exitUpTrend: 0.35,
+      enterDownTrend: -0.6,
+      exitDownTrend: -0.35,
+      chopVolRatioMax: 1.4
+    },
+    suitability: {
+      allowedVolRatioMax: 1.3,
+      extremeVolRatio: 1.6,
+      extremeCompression: 0.18,
+      minCandles: 30
+    },
+    freshness: {
+      closedCandleDelayMs: 5 * 60 * 1000,
+      softStaleMs: 75 * 60 * 1000,
+      hardStaleMs: 90 * 60 * 1000
+    }
+  }
+};
+```
+
+The `15m` entry's values are unchanged from the post-#41 file. The `1h` entry restores the pre-#41 values byte-for-byte (verified against `git show 3775905^:src/engine/marketRegime/config.ts`).
+
+- [ ] **Step 4: Run the config tests**
+
+Run:
+
+```bash
+pnpm test -- src/engine/marketRegime/__tests__/config.test.ts
+```
+
+Expected: PASS for all three new `1h` tests plus the three existing `15m` tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/engine/marketRegime/config.ts src/engine/marketRegime/__tests__/config.test.ts
+git commit -m "m42: restore 1h MARKET_REGIME_CONFIG entry alongside 15m"
+```
+
+---
+
+### Task 4: Implement `aggregateCandles` (TDD)
+
+**Files:**
+
+- Create: `src/engine/candles/aggregateCandles.ts`
+- Test: `src/engine/candles/__tests__/aggregateCandles.test.ts`
+
+The utility is dumb candle math. It must not import from `marketRegime/`, must not read the store, and must not log.
+
+- [ ] **Step 1: Write the full failing test file**
+
+Create `src/engine/candles/__tests__/aggregateCandles.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { Candle } from "../../../contract/v1/types.js";
+import { aggregateCandles } from "../aggregateCandles.js";
+
+const FIFTEEN_MIN_MS = 15 * 60 * 1000;
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+const makeCandle = (unixMs: number, overrides: Partial<Candle> = {}): Candle => ({
+  unixMs,
+  open: 100,
+  high: 101,
+  low: 99,
+  close: 100.5,
+  volume: 1,
+  ...overrides
+});
+
+const fourAlignedCandles = (hourOpenUnixMs: number): Candle[] => [
+  makeCandle(hourOpenUnixMs, { open: 100, high: 102, low: 98, close: 101, volume: 5 }),
+  makeCandle(hourOpenUnixMs + FIFTEEN_MIN_MS, {
+    open: 101,
+    high: 105,
+    low: 100,
+    close: 104,
+    volume: 7
+  }),
+  makeCandle(hourOpenUnixMs + 2 * FIFTEEN_MIN_MS, {
+    open: 104,
+    high: 106,
+    low: 103,
+    close: 105,
+    volume: 4
+  }),
+  makeCandle(hourOpenUnixMs + 3 * FIFTEEN_MIN_MS, {
+    open: 105,
+    high: 107,
+    low: 102,
+    close: 103,
+    volume: 6
+  })
+];
+
+describe("aggregateCandles 1h", () => {
+  it("aggregates four aligned 15m candles into one 1h candle", () => {
+    const hourOpen = 12 * ONE_HOUR_MS;
+    const result = aggregateCandles(fourAlignedCandles(hourOpen), "1h");
+    expect(result).toHaveLength(1);
+    expect(result[0].unixMs).toBe(hourOpen);
+    expect(result[0].open).toBe(100);
+    expect(result[0].high).toBe(107);
+    expect(result[0].low).toBe(98);
+    expect(result[0].close).toBe(103);
+    expect(result[0].volume).toBe(22);
+  });
+
+  it("emits the 1h bucket open timestamp", () => {
+    const hourOpen = 100 * ONE_HOUR_MS;
+    const result = aggregateCandles(fourAlignedCandles(hourOpen), "1h");
+    expect(result[0].unixMs).toBe(hourOpen);
+  });
+
+  it("treats input order as irrelevant and emits sorted output", () => {
+    const a = fourAlignedCandles(2 * ONE_HOUR_MS);
+    const b = fourAlignedCandles(1 * ONE_HOUR_MS);
+    const shuffled = [a[2], b[3], a[0], b[1], a[3], b[0], a[1], b[2]];
+    const result = aggregateCandles(shuffled, "1h");
+    expect(result).toHaveLength(2);
+    expect(result[0].unixMs).toBe(1 * ONE_HOUR_MS);
+    expect(result[1].unixMs).toBe(2 * ONE_HOUR_MS);
+  });
+
+  it("skips an incomplete current-hour bucket (only 3 candles present)", () => {
+    const hourOpen = 5 * ONE_HOUR_MS;
+    const partial = fourAlignedCandles(hourOpen).slice(0, 3);
+    const result = aggregateCandles(partial, "1h");
+    expect(result).toHaveLength(0);
+  });
+
+  it("skips a bucket missing a middle candle", () => {
+    const hourOpen = 5 * ONE_HOUR_MS;
+    const four = fourAlignedCandles(hourOpen);
+    const missingMiddle = [four[0], four[1], four[3]];
+    const result = aggregateCandles(missingMiddle, "1h");
+    expect(result).toHaveLength(0);
+  });
+
+  it("ignores misaligned source timestamps", () => {
+    const hourOpen = 5 * ONE_HOUR_MS;
+    const four = fourAlignedCandles(hourOpen);
+    const misaligned = [four[0], makeCandle(hourOpen + FIFTEEN_MIN_MS + 60_000), four[2], four[3]];
+    const result = aggregateCandles(misaligned, "1h");
+    expect(result).toHaveLength(0);
+  });
+
+  it("does not aggregate across hour boundaries", () => {
+    const hourOpenA = 5 * ONE_HOUR_MS;
+    const hourOpenB = 6 * ONE_HOUR_MS;
+    const incompleteA = fourAlignedCandles(hourOpenA).slice(0, 2);
+    const incompleteB = fourAlignedCandles(hourOpenB).slice(2, 4);
+    const result = aggregateCandles([...incompleteA, ...incompleteB], "1h");
+    expect(result).toHaveLength(0);
+  });
+
+  it("emits multiple complete buckets independently", () => {
+    const result = aggregateCandles(
+      [...fourAlignedCandles(0), ...fourAlignedCandles(ONE_HOUR_MS)],
+      "1h"
+    );
+    expect(result).toHaveLength(2);
+    expect(result[0].unixMs).toBe(0);
+    expect(result[1].unixMs).toBe(ONE_HOUR_MS);
+  });
+
+  it("returns an empty array for an empty input", () => {
+    expect(aggregateCandles([], "1h")).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails (file does not exist yet)**
+
+Run:
+
+```bash
+pnpm test -- src/engine/candles/__tests__/aggregateCandles.test.ts
+```
+
+Expected: FAIL with module-not-found for `../aggregateCandles.js`.
+
+- [ ] **Step 3: Implement `aggregateCandles`**
+
+Create `src/engine/candles/aggregateCandles.ts`:
+
+```ts
+import type { Candle } from "../../contract/v1/types.js";
+
+const FIFTEEN_MIN_MS = 15 * 60 * 1000;
+const ONE_HOUR_MS = 60 * 60 * 1000;
+const FIFTEEN_MINUTES_PER_HOUR = 4;
+
+type AggregationTargetTimeframe = "1h";
+
+const targetBucketMs: Record<AggregationTargetTimeframe, number> = {
+  "1h": ONE_HOUR_MS
+};
+
+const sourceTimeframeMs: Record<AggregationTargetTimeframe, number> = {
+  "1h": FIFTEEN_MIN_MS
+};
+
+const sourceCountPerBucket: Record<AggregationTargetTimeframe, number> = {
+  "1h": FIFTEEN_MINUTES_PER_HOUR
+};
+
+export const aggregateCandles = (
+  candles: Candle[],
+  target: AggregationTargetTimeframe
+): Candle[] => {
+  const bucketMs = targetBucketMs[target];
+  const srcMs = sourceTimeframeMs[target];
+  const required = sourceCountPerBucket[target];
+
+  // Group source candles by their target bucket open, dropping misaligned rows.
+  const buckets = new Map<number, Candle[]>();
+  for (const candle of candles) {
+    if (!Number.isInteger(candle.unixMs)) continue;
+    if (candle.unixMs % srcMs !== 0) continue;
+
+    const bucketOpen = Math.floor(candle.unixMs / bucketMs) * bucketMs;
+    const list = buckets.get(bucketOpen);
+    if (list) {
+      list.push(candle);
+    } else {
+      buckets.set(bucketOpen, [candle]);
+    }
+  }
+
+  const out: Candle[] = [];
+  for (const [bucketOpen, sources] of buckets) {
+    if (sources.length !== required) continue;
+
+    sources.sort((a, b) => a.unixMs - b.unixMs);
+
+    // Verify that the bucket is complete: each source slot exactly once,
+    // covering bucketOpen, bucketOpen + srcMs, ..., bucketOpen + (required-1)*srcMs.
+    let complete = true;
+    for (let i = 0; i < required; i += 1) {
+      if (sources[i].unixMs !== bucketOpen + i * srcMs) {
+        complete = false;
+        break;
+      }
+    }
+    if (!complete) continue;
+
+    let high = sources[0].high;
+    let low = sources[0].low;
+    let volume = 0;
+    for (const src of sources) {
+      if (src.high > high) high = src.high;
+      if (src.low < low) low = src.low;
+      volume += src.volume;
+    }
+
+    out.push({
+      unixMs: bucketOpen,
+      open: sources[0].open,
+      high,
+      low,
+      close: sources[required - 1].close,
+      volume
+    });
+  }
+
+  out.sort((a, b) => a.unixMs - b.unixMs);
+  return out;
+};
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run:
+
+```bash
+pnpm test -- src/engine/candles/__tests__/aggregateCandles.test.ts
+```
+
+Expected: PASS for all 9 cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/engine/candles/aggregateCandles.ts src/engine/candles/__tests__/aggregateCandles.test.ts
+git commit -m "m42: add pure aggregateCandles utility for 15m -> 1h derivation"
+```
+
+---
+
+### Task 5: Implement `regimeCandleReadPlan` (TDD)
+
+**Files:**
+
+- Create: `src/engine/marketRegime/regimeCandleReadPlan.ts`
+- Test: `src/engine/marketRegime/__tests__/regimeCandleReadPlan.test.ts`
+
+This helper centralizes the source-timeframe / read-limit / cutoff math, so the handler stays simple.
+
+- [ ] **Step 1: Write the full failing test file**
+
+Create `src/engine/marketRegime/__tests__/regimeCandleReadPlan.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { MARKET_REGIME_CONFIG } from "../config.js";
+import { closedCandleCutoffUnixMs } from "../closedCandleCutoff.js";
+import { buildRegimeCandleReadPlan } from "../regimeCandleReadPlan.js";
+
+const NOW = 1_777_000_000_000; // arbitrary fixed instant for deterministic math
+
+describe("buildRegimeCandleReadPlan(15m)", () => {
+  const plan = buildRegimeCandleReadPlan({
+    requestedTimeframe: "15m",
+    nowUnixMs: NOW
+  });
+
+  it("uses 15m as the stored source timeframe", () => {
+    expect(plan.sourceTimeframe).toBe("15m");
+  });
+
+  it("computes sourceCutoffUnixMs from the 15m freshness config", () => {
+    const cfg = MARKET_REGIME_CONFIG["15m"];
+    expect(plan.sourceCutoffUnixMs).toBe(
+      closedCandleCutoffUnixMs(NOW, cfg.timeframeMs, cfg.freshness.closedCandleDelayMs)
+    );
+  });
+
+  it("does not produce a derived cutoff", () => {
+    expect(plan.derivedCutoffUnixMs).toBeUndefined();
+  });
+
+  it("uses sourceLimit = max(volLongWindow, minCandles) + READ_BUFFER", () => {
+    const cfg = MARKET_REGIME_CONFIG["15m"];
+    const expected = Math.max(cfg.indicators.volLongWindow, cfg.suitability.minCandles) + 50;
+    expect(plan.sourceLimit).toBe(expected);
+  });
+
+  it("returns direct metadata hints", () => {
+    expect(plan.metadataHints).toEqual({ sourceTimeframe: "15m" });
+  });
+});
+
+describe("buildRegimeCandleReadPlan(1h)", () => {
+  const plan = buildRegimeCandleReadPlan({
+    requestedTimeframe: "1h",
+    nowUnixMs: NOW
+  });
+
+  it("uses 15m as the stored source timeframe", () => {
+    expect(plan.sourceTimeframe).toBe("15m");
+  });
+
+  it("computes sourceCutoffUnixMs from the 15m freshness config", () => {
+    const cfg = MARKET_REGIME_CONFIG["15m"];
+    expect(plan.sourceCutoffUnixMs).toBe(
+      closedCandleCutoffUnixMs(NOW, cfg.timeframeMs, cfg.freshness.closedCandleDelayMs)
+    );
+  });
+
+  it("computes derivedCutoffUnixMs from the 1h freshness config", () => {
+    const cfg = MARKET_REGIME_CONFIG["1h"];
+    expect(plan.derivedCutoffUnixMs).toBe(
+      closedCandleCutoffUnixMs(NOW, cfg.timeframeMs, cfg.freshness.closedCandleDelayMs)
+    );
+  });
+
+  it("uses sourceLimit = requiredDerivedBars * 4 + DERIVED_SOURCE_READ_BUFFER_15M", () => {
+    const cfg = MARKET_REGIME_CONFIG["1h"];
+    const requiredDerivedBars =
+      Math.max(cfg.indicators.volLongWindow, cfg.suitability.minCandles) + 50;
+    const expected = requiredDerivedBars * 4 + 32;
+    expect(plan.sourceLimit).toBe(expected);
+  });
+
+  it("returns derived metadata hints", () => {
+    expect(plan.metadataHints).toEqual({
+      sourceTimeframe: "15m",
+      derivedTimeframe: "1h",
+      aggregationVersion: "ohlcv-agg-v1"
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+Run:
+
+```bash
+pnpm test -- src/engine/marketRegime/__tests__/regimeCandleReadPlan.test.ts
+```
+
+Expected: FAIL with module-not-found for `../regimeCandleReadPlan.js`.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `src/engine/marketRegime/regimeCandleReadPlan.ts`:
+
+```ts
+import type { RegimeReadTimeframe } from "../../contract/v1/types.js";
+import { MARKET_REGIME_CONFIG } from "./config.js";
+import { closedCandleCutoffUnixMs } from "./closedCandleCutoff.js";
+
+const READ_BUFFER = 50;
+const FIFTEEN_MINUTES_PER_HOUR = 4;
+const DERIVED_SOURCE_READ_BUFFER_15M = 32;
+
+export interface DirectMetadataHints {
+  sourceTimeframe: "15m";
+}
+
+export interface DerivedMetadataHints {
+  sourceTimeframe: "15m";
+  derivedTimeframe: "1h";
+  aggregationVersion: "ohlcv-agg-v1";
+}
+
+export interface RegimeCandleReadPlan {
+  sourceTimeframe: "15m";
+  sourceCutoffUnixMs: number;
+  sourceLimit: number;
+  derivedCutoffUnixMs?: number;
+  metadataHints: DirectMetadataHints | DerivedMetadataHints;
+}
+
+export interface BuildRegimeCandleReadPlanInput {
+  requestedTimeframe: RegimeReadTimeframe;
+  nowUnixMs: number;
+}
+
+export const buildRegimeCandleReadPlan = (
+  input: BuildRegimeCandleReadPlanInput
+): RegimeCandleReadPlan => {
+  const sourceConfig = MARKET_REGIME_CONFIG["15m"];
+  const sourceCutoffUnixMs = closedCandleCutoffUnixMs(
+    input.nowUnixMs,
+    sourceConfig.timeframeMs,
+    sourceConfig.freshness.closedCandleDelayMs
+  );
+
+  if (input.requestedTimeframe === "15m") {
+    const requestedConfig = MARKET_REGIME_CONFIG["15m"];
+    const sourceLimit =
+      Math.max(requestedConfig.indicators.volLongWindow, requestedConfig.suitability.minCandles) +
+      READ_BUFFER;
+
+    return {
+      sourceTimeframe: "15m",
+      sourceCutoffUnixMs,
+      sourceLimit,
+      metadataHints: { sourceTimeframe: "15m" }
+    };
+  }
+
+  const derivedConfig = MARKET_REGIME_CONFIG["1h"];
+  const derivedCutoffUnixMs = closedCandleCutoffUnixMs(
+    input.nowUnixMs,
+    derivedConfig.timeframeMs,
+    derivedConfig.freshness.closedCandleDelayMs
+  );
+  const requiredDerivedBars =
+    Math.max(derivedConfig.indicators.volLongWindow, derivedConfig.suitability.minCandles) +
+    READ_BUFFER;
+  const sourceLimit =
+    requiredDerivedBars * FIFTEEN_MINUTES_PER_HOUR + DERIVED_SOURCE_READ_BUFFER_15M;
+
+  return {
+    sourceTimeframe: "15m",
+    sourceCutoffUnixMs,
+    sourceLimit,
+    derivedCutoffUnixMs,
+    metadataHints: {
+      sourceTimeframe: "15m",
+      derivedTimeframe: "1h",
+      aggregationVersion: "ohlcv-agg-v1"
+    }
+  };
+};
+```
+
+- [ ] **Step 4: Run the read-plan tests**
+
+Run:
+
+```bash
+pnpm test -- src/engine/marketRegime/__tests__/regimeCandleReadPlan.test.ts
+```
+
+Expected: PASS for all 10 cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/engine/marketRegime/regimeCandleReadPlan.ts src/engine/marketRegime/__tests__/regimeCandleReadPlan.test.ts
+git commit -m "m42: add regimeCandleReadPlan helper for direct vs derived reads"
+```
+
+---
+
+### Task 6: Extend `buildRegimeCurrent` with caller-supplied metadata
+
+`buildRegimeCurrent` must remain source-agnostic; it just merges fields the handler supplies.
+
+**Files:**
+
+- Modify: `src/engine/marketRegime/buildRegimeCurrent.ts`
+- Test: `src/engine/marketRegime/__tests__/buildRegimeCurrent.test.ts`
+- Test: `src/engine/marketRegime/__tests__/buildRegimeCurrent.snapshot.test.ts`
+
+- [ ] **Step 1: Add a failing test asserting the new metadata fields are reflected**
+
+Open `src/engine/marketRegime/__tests__/buildRegimeCurrent.test.ts`.
+
+Append this test to the existing `describe` block:
+
+```ts
+it("merges caller-supplied source/derived metadata fields into the response", () => {
+  const lastCandleUnixMs = flatCandles[flatCandles.length - 1].unixMs;
+  const response = buildRegimeCurrent({
+    feed: { ...feed, timeframe: "1h" as const },
+    candles: flatCandles,
+    nowUnixMs: lastCandleUnixMs + 20 * 60 * 1000,
+    config: MARKET_REGIME_CONFIG["1h"],
+    configVersion: "market-regime-2.0.0",
+    engineVersion: "0.1.0",
+    metadata: {
+      sourceTimeframe: "15m",
+      sourceCandleCount: 520,
+      derivedTimeframe: "1h",
+      aggregationVersion: "ohlcv-agg-v1"
+    }
+  });
+  expect(response.timeframe).toBe("1h");
+  expect(response.metadata.sourceTimeframe).toBe("15m");
+  expect(response.metadata.sourceCandleCount).toBe(520);
+  expect(response.metadata.derivedTimeframe).toBe("1h");
+  expect(response.metadata.aggregationVersion).toBe("ohlcv-agg-v1");
+  expect(response.metadata.candleCount).toBe(130);
+});
+
+it("omits derived metadata fields when caller provides only source fields", () => {
+  const lastCandleUnixMs = flatCandles[flatCandles.length - 1].unixMs;
+  const response = buildRegimeCurrent({
+    feed,
+    candles: flatCandles,
+    nowUnixMs: lastCandleUnixMs + 20 * 60 * 1000,
+    config: MARKET_REGIME_CONFIG["15m"],
+    configVersion: "market-regime-2.0.0",
+    engineVersion: "0.1.0",
+    metadata: {
+      sourceTimeframe: "15m",
+      sourceCandleCount: 130
+    }
+  });
+  expect(response.metadata.sourceTimeframe).toBe("15m");
+  expect(response.metadata.sourceCandleCount).toBe(130);
+  expect(response.metadata.derivedTimeframe).toBeUndefined();
+  expect(response.metadata.aggregationVersion).toBeUndefined();
+});
+```
+
+Also, in the same file, update each existing call to `buildRegimeCurrent` so that the call type-checks against the new mandatory metadata shape. For each existing call (the three currently in this file), add a `metadata` field:
+
+```ts
+      metadata: { sourceTimeframe: "15m", sourceCandleCount: flatCandles.length }
+```
+
+(or `fewCandles.length` for the few-candles case). The exact insertion point is after `engineVersion: "0.1.0"`.
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+Run:
+
+```bash
+pnpm test -- src/engine/marketRegime/__tests__/buildRegimeCurrent.test.ts
+```
+
+Expected: FAIL — `BuildRegimeCurrentInput` does not yet accept `metadata`, so the test will fail to type-check.
+
+- [ ] **Step 3: Extend `buildRegimeCurrent`**
+
+Open `src/engine/marketRegime/buildRegimeCurrent.ts`. Replace the file contents with:
+
+```ts
+import { computeIndicators } from "../features/indicators.js";
+import type {
+  Candle,
+  MarketReason,
+  RegimeCurrentResponse,
+  RegimeReadTimeframe
+} from "../../contract/v1/types.js";
+import { SCHEMA_VERSION } from "../../contract/v1/types.js";
+import { classifyMarketRegime } from "./classifyMarketRegime.js";
+import { computeFreshness } from "./freshness.js";
+import { evaluateMarketClmmSuitability } from "./evaluateMarketClmmSuitability.js";
+import type { MarketTimeframeConfig } from "./config.js";
+
+export interface BuildRegimeCurrentMetadata {
+  sourceTimeframe: "15m";
+  sourceCandleCount: number;
+  derivedTimeframe?: "1h";
+  aggregationVersion?: "ohlcv-agg-v1";
+}
+
+export interface BuildRegimeCurrentInput {
+  feed: {
+    symbol: string;
+    source: string;
+    network: string;
+    poolAddress: string;
+    timeframe: RegimeReadTimeframe;
+  };
+  candles: Candle[];
+  nowUnixMs: number;
+  config: MarketTimeframeConfig;
+  configVersion: string;
+  engineVersion: string;
+  metadata: BuildRegimeCurrentMetadata;
+}
+
+const buildMarketReasons = (
+  regimeReasons: MarketReason[],
+  freshness: { hardStale: boolean; softStale: boolean },
+  candleCount: number,
+  minCandles: number
+): MarketReason[] => {
+  const out: MarketReason[] = [...regimeReasons];
+
+  if (freshness.hardStale) {
+    out.push({
+      code: "DATA_HARD_STALE",
+      severity: "ERROR",
+      message: "Latest candle is older than the hard-stale window."
+    });
+  } else if (freshness.softStale) {
+    out.push({
+      code: "DATA_SOFT_STALE",
+      severity: "WARN",
+      message: "Latest candle is older than the soft-stale window."
+    });
+  } else {
+    out.push({
+      code: "DATA_FRESH",
+      severity: "INFO",
+      message: "Latest candle is within the freshness window."
+    });
+  }
+
+  if (candleCount >= minCandles) {
+    out.push({
+      code: "DATA_SUFFICIENT_SAMPLES",
+      severity: "INFO",
+      message: `Have ${candleCount} closed candles (>= ${minCandles}).`
+    });
+  } else {
+    out.push({
+      code: "DATA_INSUFFICIENT_SAMPLES",
+      severity: "ERROR",
+      message: `Have ${candleCount} closed candles; need at least ${minCandles}.`
+    });
+  }
+
+  return out;
+};
+
+export const buildRegimeCurrent = (input: BuildRegimeCurrentInput): RegimeCurrentResponse => {
+  if (input.candles.length === 0) {
+    throw new Error("buildRegimeCurrent requires at least one candle");
+  }
+  const { feed, candles, nowUnixMs, config, configVersion, engineVersion, metadata } = input;
+
+  const telemetry = computeIndicators(candles, config.indicators);
+  const { regime, reasons: regimeReasons } = classifyMarketRegime(telemetry, config.regime);
+
+  const lastCandleUnixMs = candles[candles.length - 1].unixMs;
+  const freshness = computeFreshness(nowUnixMs, lastCandleUnixMs, {
+    softStaleMs: config.freshness.softStaleMs,
+    hardStaleMs: config.freshness.hardStaleMs
+  });
+
+  const suitability = evaluateMarketClmmSuitability({
+    regime,
+    telemetry,
+    freshness: { hardStale: freshness.hardStale, softStale: freshness.softStale },
+    candleCount: candles.length,
+    config: config.suitability
+  });
+
+  const marketReasons = buildMarketReasons(
+    regimeReasons,
+    { hardStale: freshness.hardStale, softStale: freshness.softStale },
+    candles.length,
+    config.suitability.minCandles
+  );
+
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    symbol: feed.symbol,
+    source: feed.source,
+    network: feed.network,
+    poolAddress: feed.poolAddress,
+    timeframe: feed.timeframe,
+    regime,
+    telemetry,
+    clmmSuitability: suitability,
+    marketReasons,
+    freshness,
+    metadata: {
+      engineVersion,
+      configVersion,
+      candleCount: candles.length,
+      sourceTimeframe: metadata.sourceTimeframe,
+      sourceCandleCount: metadata.sourceCandleCount,
+      ...(metadata.derivedTimeframe !== undefined
+        ? { derivedTimeframe: metadata.derivedTimeframe }
+        : {}),
+      ...(metadata.aggregationVersion !== undefined
+        ? { aggregationVersion: metadata.aggregationVersion }
+        : {})
+    }
+  };
+};
+```
+
+`metadata` is required from the caller. Direct callers pass `sourceTimeframe: "15m", sourceCandleCount: candles.length`. Derived callers pass all four fields.
+
+- [ ] **Step 4: Update the snapshot test to pass new metadata**
+
+Open `src/engine/marketRegime/__tests__/buildRegimeCurrent.snapshot.test.ts`.
+
+Find:
+
+```ts
+      configVersion: MARKET_REGIME_CONFIG_VERSION,
+      engineVersion: "0.1.0"
+    });
+```
+
+Replace with:
+
+```ts
+      configVersion: MARKET_REGIME_CONFIG_VERSION,
+      engineVersion: "0.1.0",
+      metadata: {
+        sourceTimeframe: "15m",
+        sourceCandleCount: goldenCandles.length
+      }
+    });
+```
+
+- [ ] **Step 5: Run the snapshot test and update the snapshot**
+
+The snapshot output now includes new fields. Run:
+
+```bash
+pnpm test -- src/engine/marketRegime/__tests__/buildRegimeCurrent.snapshot.test.ts -u
+```
+
+Expected: PASS, with the snapshot file updated to include `sourceTimeframe: "15m"` and `sourceCandleCount: 130` in `metadata`. After it passes, run without `-u` to confirm:
+
+```bash
+pnpm test -- src/engine/marketRegime/__tests__/buildRegimeCurrent.snapshot.test.ts
+```
+
+Expected: PASS, no snapshot drift.
+
+- [ ] **Step 6: Run the full marketRegime suite**
+
+Run:
+
+```bash
+pnpm test -- src/engine/marketRegime
+```
+
+Expected: PASS for all marketRegime tests, including the two new metadata tests in `buildRegimeCurrent.test.ts`, the snapshot test, and the `1h` config tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/engine/marketRegime/buildRegimeCurrent.ts \
+        src/engine/marketRegime/__tests__/buildRegimeCurrent.test.ts \
+        src/engine/marketRegime/__tests__/buildRegimeCurrent.snapshot.test.ts \
+        src/engine/marketRegime/__tests__/__snapshots__
+git commit -m "m42: thread caller-supplied metadata fields through buildRegimeCurrent"
+```
+
+(If `__snapshots__` does not exist as a tracked path under `__tests__`, omit it from `git add`; the regenerated snapshot file will surface as a normal modification under the existing snapshots directory.)
+
+---
+
+### Task 7: Rewrite `regimeCurrent` handler to orchestrate direct vs derived
+
+**Files:**
+
+- Modify: `src/http/handlers/regimeCurrent.ts`
+
+This rewrite removes the local `READ_BUFFER` constant and the inline cutoff math, replacing them with `buildRegimeCandleReadPlan`. The store call always reads `15m` rows, regardless of the requested regime-read timeframe.
+
+- [ ] **Step 1: Replace the handler implementation**
+
+Open `src/http/handlers/regimeCurrent.ts`. Replace the file contents with:
+
+```ts
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { parseRegimeCurrentQuery } from "../../contract/v1/validation.js";
+import { candlesNotFoundError, ContractValidationError } from "../errors.js";
+import type { LedgerStore } from "../../ledger/store.js";
+import { getLatestCandlesForFeed } from "../../ledger/candlesWriter.js";
+import type { CandleStore } from "../../ledger/candleStore.js";
+import {
+  MARKET_REGIME_CONFIG,
+  MARKET_REGIME_CONFIG_VERSION
+} from "../../engine/marketRegime/config.js";
+import { buildRegimeCurrent } from "../../engine/marketRegime/buildRegimeCurrent.js";
+import { buildRegimeCandleReadPlan } from "../../engine/marketRegime/regimeCandleReadPlan.js";
+import { aggregateCandles } from "../../engine/candles/aggregateCandles.js";
+
+export const createRegimeCurrentHandler = (store: LedgerStore, candleStore?: CandleStore) => {
+  return async (request: FastifyRequest, reply: FastifyReply) => {
+    try {
+      const query = parseRegimeCurrentQuery(request.query);
+      const config = MARKET_REGIME_CONFIG[query.timeframe];
+
+      const nowUnixMs = Date.now();
+      const plan = buildRegimeCandleReadPlan({
+        requestedTimeframe: query.timeframe,
+        nowUnixMs
+      });
+
+      const sourceCandles = candleStore
+        ? await candleStore.getLatestCandlesForFeed({
+            symbol: query.symbol,
+            source: query.source,
+            network: query.network,
+            poolAddress: query.poolAddress,
+            timeframe: plan.sourceTimeframe,
+            closedCandleCutoffUnixMs: plan.sourceCutoffUnixMs,
+            limit: plan.sourceLimit
+          })
+        : await Promise.resolve(
+            getLatestCandlesForFeed(store, {
+              symbol: query.symbol,
+              source: query.source,
+              network: query.network,
+              poolAddress: query.poolAddress,
+              timeframe: plan.sourceTimeframe,
+              closedCandleCutoffUnixMs: plan.sourceCutoffUnixMs,
+              limit: plan.sourceLimit
+            })
+          );
+
+      if (sourceCandles.length === 0) {
+        throw candlesNotFoundError(
+          `No closed candles found for symbol="${query.symbol}", source="${query.source}", ` +
+            `network="${query.network}", poolAddress="${query.poolAddress}", ` +
+            `sourceTimeframe="${plan.sourceTimeframe}", requestedTimeframe="${query.timeframe}".`
+        );
+      }
+
+      let classifiedCandles = sourceCandles;
+      if (query.timeframe === "1h") {
+        const aggregated = aggregateCandles(sourceCandles, "1h");
+        classifiedCandles = aggregated.filter(
+          (candle) => candle.unixMs <= (plan.derivedCutoffUnixMs as number)
+        );
+        if (classifiedCandles.length === 0) {
+          throw candlesNotFoundError(
+            `No complete derived 1h candles available before the 1h freshness cutoff for ` +
+              `symbol="${query.symbol}", source="${query.source}", network="${query.network}", ` +
+              `poolAddress="${query.poolAddress}".`
+          );
+        }
+      }
+
+      const response = buildRegimeCurrent({
+        feed: {
+          symbol: query.symbol,
+          source: query.source,
+          network: query.network,
+          poolAddress: query.poolAddress,
+          timeframe: query.timeframe
+        },
+        candles: classifiedCandles,
+        nowUnixMs,
+        config,
+        configVersion: MARKET_REGIME_CONFIG_VERSION,
+        engineVersion: process.env.npm_package_version ?? "0.0.0",
+        metadata: {
+          ...plan.metadataHints,
+          sourceCandleCount: sourceCandles.length
+        }
+      });
+
+      return reply.code(200).send(response);
+    } catch (error) {
+      if (error instanceof ContractValidationError) {
+        return reply.code(error.statusCode).send(error.response);
+      }
+      request.log.error(error, "Unhandled error in GET /v1/regime/current");
+      return reply.code(500).send({
+        schemaVersion: "1.0",
+        error: { code: "INTERNAL_ERROR", message: "Internal server error", details: [] }
+      });
+    }
+  };
+};
+```
+
+Notes:
+
+- The store always reads `plan.sourceTimeframe = "15m"`, regardless of `query.timeframe`.
+- For derived `1h`, we aggregate then filter by the `1h` derived cutoff. Empty post-filter returns `CANDLES_NOT_FOUND`.
+- For derived `1h`, if aggregation yields some derived candles but fewer than `MARKET_REGIME_CONFIG["1h"].suitability.minCandles`, we still call `buildRegimeCurrent`, which surfaces `DATA_INSUFFICIENT_SAMPLES` via the existing path.
+- `sourceCandleCount` in metadata is the actual `15m` row count returned by the store before aggregation/filtering, per the spec.
+
+- [ ] **Step 2: Run typecheck**
+
+Run:
+
+```bash
+pnpm typecheck
+```
+
+Expected: PASS. The handler change should now be type-clean.
+
+- [ ] **Step 3: Run the existing handler e2e tests** (we'll add new ones in Task 8)
+
+Run:
+
+```bash
+pnpm test -- src/http/__tests__/regimeCurrent.e2e.test.ts src/http/__tests__/candleFallback.e2e.test.ts
+```
+
+Expected: PASS for the existing direct `15m` cases — the new orchestration must not regress them. (If it does, fix before moving on.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/http/handlers/regimeCurrent.ts
+git commit -m "m42: orchestrate direct 15m and derived 1h reads in regimeCurrent handler"
+```
+
+---
+
+### Task 8: Add and update regime-current e2e tests
+
+**Files:**
+
+- Modify: `src/http/__tests__/regimeCurrent.e2e.test.ts`
+
+The existing direct-`15m` e2e cases need a metadata-shape upgrade, and we add five new cases that exercise the derived `1h` flow against real ingested `15m` candles. Build all candles relative to the current real wall clock so they are within the freshness windows used by the regime engine; aligned timestamps land on `15m` boundaries in real time.
+
+- [ ] **Step 1: Add direct-`15m` metadata assertions to the existing 200 case**
+
+Open `src/http/__tests__/regimeCurrent.e2e.test.ts`.
+
+Find this existing assertion block (inside the "returns 200 with regime and suitability fields for sufficient CHOP candles" test):
+
+```ts
+expect(body.metadata.candleCount).toBeGreaterThanOrEqual(
+  MARKET_REGIME_CONFIG["15m"].suitability.minCandles
+);
+```
+
+Insert the following lines immediately after it:
+
+```ts
+expect(body.metadata.sourceTimeframe).toBe("15m");
+expect(body.metadata.sourceCandleCount).toBe(body.metadata.candleCount);
+expect(body.metadata.derivedTimeframe).toBeUndefined();
+expect(body.metadata.aggregationVersion).toBeUndefined();
+```
+
+- [ ] **Step 2: Add a new derived-`1h` query string constant and ingest helper**
+
+Near the top of the file, after the existing `queryString` constant, add:
+
+```ts
+const queryString1h =
+  "?symbol=SOL%2FUSDC&source=birdeye&network=solana-mainnet&poolAddress=Pool111&timeframe=1h";
+```
+
+The existing `buildRecentCandles` and `ingestPayload` helpers already build `15m`-aligned candles relative to wall-clock; reuse them.
+
+- [ ] **Step 3: Add a derived-`1h` success test**
+
+Append the following inside the existing `describe("GET /v1/regime/current", ...)` block (after the existing tests, before the closing `});`):
+
+```ts
+it("returns 200 with derived 1h regime classified from stored 15m candles", async () => {
+  process.env.LEDGER_DB_PATH = tempDb();
+  process.env.CANDLES_INGEST_TOKEN = "test-token";
+  const app = buildApp();
+
+  const recordedIso = new Date().toISOString();
+  // Need at least minCandles(1h) = 30 derived bars; each 1h bar needs 4 aligned 15m bars,
+  // plus headroom for the freshness cutoff filter. 200 source bars is more than enough.
+  await app.inject({
+    method: "POST",
+    url: "/v1/candles",
+    headers: { "X-Candles-Ingest-Token": "test-token" },
+    payload: ingestPayload(200, recordedIso)
+  });
+
+  const res = await app.inject({ method: "GET", url: `/v1/regime/current${queryString1h}` });
+  expect(res.statusCode).toBe(200);
+  const body = res.json();
+  expect(body.schemaVersion).toBe("1.0");
+  expect(body.timeframe).toBe("1h");
+  expect(["UP", "DOWN", "CHOP"]).toContain(body.regime);
+  expect(body.metadata.sourceTimeframe).toBe("15m");
+  expect(body.metadata.sourceCandleCount).toBeGreaterThanOrEqual(body.metadata.candleCount * 4);
+  expect(body.metadata.derivedTimeframe).toBe("1h");
+  expect(body.metadata.aggregationVersion).toBe("ohlcv-agg-v1");
+  expect(body.metadata.candleCount).toBeGreaterThan(0);
+  expect(Array.isArray(body.marketReasons)).toBe(true);
+});
+```
+
+- [ ] **Step 4: Add a derived-`1h` excludes-incomplete-current-bucket test**
+
+Append:
+
+```ts
+it("derived 1h does not classify the incomplete current-hour aggregate", async () => {
+  process.env.LEDGER_DB_PATH = tempDb();
+  process.env.CANDLES_INGEST_TOKEN = "test-token";
+  const app = buildApp();
+
+  await app.inject({
+    method: "POST",
+    url: "/v1/candles",
+    headers: { "X-Candles-Ingest-Token": "test-token" },
+    payload: ingestPayload(200, new Date().toISOString())
+  });
+
+  const res = await app.inject({ method: "GET", url: `/v1/regime/current${queryString1h}` });
+  expect(res.statusCode).toBe(200);
+  const body = res.json();
+
+  // The derived bar at the most recent classified bucket should be strictly older than now.
+  expect(body.freshness.lastCandleUnixMs).toBeLessThan(Date.now());
+
+  // It should also be older than the most recent stored 15m bucket (since 1h derived bars
+  // open on hour boundaries and the most recent 15m bar may be inside the current hour).
+  const ONE_HOUR_MS = 60 * 60 * 1000;
+  expect(body.freshness.lastCandleUnixMs % ONE_HOUR_MS).toBe(0);
+});
+```
+
+- [ ] **Step 5: Add a derived-`1h` zero-candles-after-aggregation test**
+
+Append:
+
+```ts
+it("returns 404 CANDLES_NOT_FOUND when no derived 1h bars survive the cutoff", async () => {
+  process.env.LEDGER_DB_PATH = tempDb();
+  process.env.CANDLES_INGEST_TOKEN = "test-token";
+  const app = buildApp();
+
+  const FIFTEEN_MIN_MS = 15 * 60 * 1000;
+  const ONE_HOUR_MS = 60 * 60 * 1000;
+  const sourceConfig = MARKET_REGIME_CONFIG["15m"];
+
+  // Build three 15m candles inside a single hour bucket so aggregation yields no
+  // complete 1h candle. Anchor the bucket recently so it survives the 15m source cutoff.
+  const sourceCutoffUnixMs =
+    Math.floor((Date.now() - sourceConfig.freshness.closedCandleDelayMs) / FIFTEEN_MIN_MS) *
+      FIFTEEN_MIN_MS -
+    FIFTEEN_MIN_MS;
+  const hourOpen =
+    Math.floor((sourceCutoffUnixMs - 4 * FIFTEEN_MIN_MS) / ONE_HOUR_MS) * ONE_HOUR_MS;
+  const partialCandles = [0, 1, 2].map((i) => ({
+    unixMs: hourOpen + i * FIFTEEN_MIN_MS,
+    open: 100,
+    high: 100.5,
+    low: 99.5,
+    close: 100,
+    volume: 1
+  }));
+
+  await app.inject({
+    method: "POST",
+    url: "/v1/candles",
+    headers: { "X-Candles-Ingest-Token": "test-token" },
+    payload: {
+      schemaVersion: "1.0",
+      source: "birdeye",
+      network: "solana-mainnet",
+      poolAddress: "Pool111",
+      symbol: "SOL/USDC",
+      timeframe: "15m",
+      sourceRecordedAtIso: new Date().toISOString(),
+      candles: partialCandles
+    }
+  });
+
+  const res = await app.inject({ method: "GET", url: `/v1/regime/current${queryString1h}` });
+  expect(res.statusCode).toBe(404);
+  expect(res.json().error.code).toBe("CANDLES_NOT_FOUND");
+});
+```
+
+- [ ] **Step 6: Add an insufficient-derived-samples test (nonzero but below minCandles)**
+
+Append:
+
+```ts
+it("derived 1h with non-zero but insufficient derived bars returns DATA_INSUFFICIENT_SAMPLES", async () => {
+  process.env.LEDGER_DB_PATH = tempDb();
+  process.env.CANDLES_INGEST_TOKEN = "test-token";
+  const app = buildApp();
+
+  const FIFTEEN_MIN_MS = 15 * 60 * 1000;
+  const ONE_HOUR_MS = 60 * 60 * 1000;
+  const sourceConfig = MARKET_REGIME_CONFIG["15m"];
+
+  // Produce ~5 complete 1h derived bars: 5 * 4 = 20 source 15m bars,
+  // anchored before the 15m source cutoff so they all read back.
+  const sourceCutoffUnixMs =
+    Math.floor((Date.now() - sourceConfig.freshness.closedCandleDelayMs) / FIFTEEN_MIN_MS) *
+      FIFTEEN_MIN_MS -
+    FIFTEEN_MIN_MS;
+  const lastHourOpen = Math.floor(sourceCutoffUnixMs / ONE_HOUR_MS) * ONE_HOUR_MS - ONE_HOUR_MS;
+  const startHourOpen = lastHourOpen - 4 * ONE_HOUR_MS;
+  const candles: Array<{
+    unixMs: number;
+    open: number;
+    high: number;
+    low: number;
+    close: number;
+    volume: number;
+  }> = [];
+  for (let h = 0; h < 5; h += 1) {
+    for (let q = 0; q < 4; q += 1) {
+      candles.push({
+        unixMs: startHourOpen + h * ONE_HOUR_MS + q * FIFTEEN_MIN_MS,
+        open: 100,
+        high: 100.5,
+        low: 99.5,
+        close: 100,
+        volume: 1
+      });
+    }
+  }
+
+  await app.inject({
+    method: "POST",
+    url: "/v1/candles",
+    headers: { "X-Candles-Ingest-Token": "test-token" },
+    payload: {
+      schemaVersion: "1.0",
+      source: "birdeye",
+      network: "solana-mainnet",
+      poolAddress: "Pool111",
+      symbol: "SOL/USDC",
+      timeframe: "15m",
+      sourceRecordedAtIso: new Date().toISOString(),
+      candles
+    }
+  });
+
+  const res = await app.inject({ method: "GET", url: `/v1/regime/current${queryString1h}` });
+  expect(res.statusCode).toBe(200);
+  const body = res.json();
+  expect(body.metadata.candleCount).toBeLessThan(MARKET_REGIME_CONFIG["1h"].suitability.minCandles);
+  expect(body.marketReasons.map((r: { code: string }) => r.code)).toContain(
+    "DATA_INSUFFICIENT_SAMPLES"
+  );
+  expect(body.clmmSuitability.status).toBe("UNKNOWN");
+});
+```
+
+- [ ] **Step 7: Add an empty-source test for derived 1h (separate from CANDLES_NOT_FOUND-after-aggregation)**
+
+Append:
+
+```ts
+it("returns 404 CANDLES_NOT_FOUND for derived 1h when no 15m source candles exist at all", async () => {
+  process.env.LEDGER_DB_PATH = tempDb();
+  const app = buildApp();
+  const res = await app.inject({ method: "GET", url: `/v1/regime/current${queryString1h}` });
+  expect(res.statusCode).toBe(404);
+  expect(res.json().error.code).toBe("CANDLES_NOT_FOUND");
+});
+```
+
+- [ ] **Step 8: Run the full e2e suite**
+
+Run:
+
+```bash
+pnpm test -- src/http/__tests__/regimeCurrent.e2e.test.ts
+```
+
+Expected: PASS for the existing direct-`15m` cases plus the five new derived-`1h` cases.
+
+Also re-run the fallback test:
+
+```bash
+pnpm test -- src/http/__tests__/candleFallback.e2e.test.ts
+```
+
+Expected: PASS — the fallback test still reads `15m` and asserts `CANDLES_NOT_FOUND`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/http/__tests__/regimeCurrent.e2e.test.ts
+git commit -m "m42: cover derived 1h regime reads with end-to-end tests"
+```
+
+---
+
+### Task 9: Update OpenAPI
+
+**Files:**
+
+- Modify: `src/http/openapi.ts`
+
+- [ ] **Step 1: Widen the `/v1/regime/current` `timeframe` enum and refresh summary**
+
+Open `src/http/openapi.ts`.
+
+Find:
+
+```ts
+      "/v1/regime/current": {
+        get: {
+          summary:
+            "Market-only regime classification + CLMM suitability for a 15m feed (timeframe must be 15m; 1h removed, see #41/#42)",
+```
+
+Replace with:
+
+```ts
+      "/v1/regime/current": {
+        get: {
+          summary:
+            "Market-only regime classification + CLMM suitability. timeframe=15m classifies stored 15m candles directly; timeframe=1h derives complete 1h candles from stored 15m candles on the fly.",
+```
+
+Then find:
+
+```ts
+            {
+              name: "timeframe",
+              in: "query",
+              required: true,
+              schema: { type: "string", enum: ["15m"] }
+            }
+```
+
+Replace with:
+
+```ts
+            {
+              name: "timeframe",
+              in: "query",
+              required: true,
+              schema: { type: "string", enum: ["15m", "1h"] }
+            }
+```
+
+- [ ] **Step 2: Tighten the `/v1/candles` summary note (still 15m only)**
+
+Find:
+
+```ts
+      "/v1/candles": {
+        post: {
+          summary:
+            "Ingest candle revisions for a logical feed (timeframe must be 15m; 1h removed in #41 until #42 derives 1h from 15m)",
+```
+
+Replace with:
+
+```ts
+      "/v1/candles": {
+        post: {
+          summary:
+            "Ingest candle revisions for a logical feed. Provider ingestion is restricted to timeframe=15m; 1h regime reads are derived from stored 15m candles by GET /v1/regime/current.",
+```
+
+- [ ] **Step 3: Run typecheck and the openapi-related tests if any exist**
+
+Run:
+
+```bash
+pnpm typecheck
+```
+
+Expected: PASS.
+
+If there are openapi tests, run them; otherwise the TS shape is sufficient validation here:
+
+```bash
+pnpm test -- src/http/__tests__/routes.contract.test.ts
+```
+
+Expected: PASS (the existing contract test does not depend on the openapi text changes).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/http/openapi.ts
+git commit -m "m42: widen /v1/regime/current timeframe enum to [15m, 1h] in openapi"
+```
+
+---
+
+### Task 10: Update README
+
+**Files:**
+
+- Modify: `README.md`
+
+- [ ] **Step 1: Replace the `#41` contract-change note**
+
+Open `README.md`.
+
+Find:
+
+```md
+- `GET /v1/regime/current?symbol=&source=&network=&poolAddress=&timeframe=15m` —
+  market-only regime classification + CLMM suitability. Stateless: no
+  `RegimeState`, no portfolio/autopilot inputs, no plan-ledger writes.
+```
+
+Replace with:
+
+```md
+- `GET /v1/regime/current?symbol=&source=&network=&poolAddress=&timeframe=15m|1h` —
+  market-only regime classification + CLMM suitability. `timeframe=15m`
+  classifies stored 15m candles directly; `timeframe=1h` derives complete 1h
+  candles from stored 15m candles on the fly. Stateless: no `RegimeState`, no
+  portfolio/autopilot inputs, no plan-ledger writes.
+```
+
+Then find:
+
+```md
+> **#41 contract change:** `POST /v1/candles` and `GET /v1/regime/current` accept `timeframe=15m` only. `timeframe=1h` is removed and is restored as a derived read in #42 (1h derived from stored 15m candles). Coordinate consumers before deploying.
+```
+
+Replace with:
+
+```md
+> **#41 / #42 contract:** `POST /v1/candles` accepts `timeframe=15m` only (provider ingestion is canonical at 15m). `GET /v1/regime/current` accepts `timeframe=15m | 1h`. The `1h` regime read is derived on the fly from stored 15m candles (no provider-ingested 1h candles, no derived storage). Response metadata includes `sourceTimeframe`, `sourceCandleCount`, and on derived reads `derivedTimeframe` and `aggregationVersion`.
+```
+
+- [ ] **Step 2: Update the `GECKO_TIMEFRAME` row to drop the `#41 until #42` qualifier**
+
+Find:
+
+```md
+| `GECKO_TIMEFRAME` | `15m` | Must equal `15m`. (`1h` is removed in #41 until #42.) |
+```
+
+Replace with:
+
+```md
+| `GECKO_TIMEFRAME` | `15m` | Must equal `15m`. Provider ingestion is canonical at 15m; 1h regime reads are derived. |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "m42: refresh README to describe derived 1h regime reads"
+```
+
+---
+
+### Task 11: Quality gate
+
+- [ ] **Step 1: Run typecheck, lint, full test suite, and build**
+
+Run:
+
+```bash
+pnpm typecheck && pnpm lint && pnpm test && pnpm build
+```
+
+Expected: all four steps PASS. If any step fails, fix at the root cause (do not paper over with `-- --no-verify`-style escapes); re-run the gate.
+
+- [ ] **Step 2: Confirm no stray `1h` regime-read rejection text remains**
+
+Run:
+
+```bash
+grep -RIn "1h removed" src docs README.md || true
+grep -RIn "until #42" src docs README.md || true
+grep -RIn "rejects timeframe=1h" src/contract/v1/__tests__ || true
+```
+
+Expected: no matches in `src/` or `README.md`. (Hits in `docs/` are likely just historical specs / compounded learnings — fine.)
+
+- [ ] **Step 3: Confirm no `1h` ingestion regression**
+
+Run:
+
+```bash
+pnpm test -- src/http/__tests__/candles.e2e.test.ts src/contract/v1/__tests__/candles.validation.test.ts
+```
+
+Expected: PASS — `POST /v1/candles` still rejects `timeframe: "1h"`.
+
+- [ ] **Step 4: Confirm derived metadata round-trips end to end**
+
+Quickly sanity-check the response shape:
+
+```bash
+pnpm test -- src/http/__tests__/regimeCurrent.e2e.test.ts -t "derived 1h"
+```
+
+Expected: PASS for all four `derived 1h` cases.
+
+- [ ] **Step 5: Final commit (only if any small fixups landed during the gate)**
+
+```bash
+git status
+```
+
+If any changes were made during the gate, commit them with a focused message such as `m42: address quality-gate findings`.
+
+---
+
+## Acceptance Criteria
+
+This plan is complete when:
+
+- `CandleIngestTimeframe` is still `"15m"` and `POST /v1/candles` still rejects `timeframe: "1h"`.
+- `RegimeReadTimeframe` is `"15m" | "1h"`.
+- `MARKET_REGIME_CONFIG` has both a `"15m"` and a `"1h"` entry, with the `1h` entry restoring the pre-#41 windows and freshness thresholds.
+- `aggregateCandles(candles, "1h")` is pure: emits sorted complete-bucket derived candles, skips incomplete/misaligned/cross-hour cases, never synthesizes.
+- `buildRegimeCandleReadPlan` correctly returns `15m` source identity, source/derived cutoffs, source limit, and metadata hints for both regime-read timeframes.
+- `GET /v1/regime/current?timeframe=15m` still works, with response metadata now including `sourceTimeframe="15m"` and `sourceCandleCount === candleCount`.
+- `GET /v1/regime/current?timeframe=1h` returns a regime classified on derived `1h` candles aggregated from stored `15m` rows; metadata includes `sourceTimeframe`, `sourceCandleCount`, `derivedTimeframe`, and `aggregationVersion`.
+- Derived current-hour incomplete buckets are excluded; derived zero-after-filter returns `CANDLES_NOT_FOUND`; derived nonzero-but-insufficient surfaces `DATA_INSUFFICIENT_SAMPLES` via `buildRegimeCurrent`.
+- No new database tables, migrations, or provider-1h ingestion paths are added.
+- `pnpm typecheck && pnpm lint && pnpm test && pnpm build` all pass.
+
+---
+
+## Self-review notes
+
+This plan covers every section of the spec:
+
+- Public Contract → Tasks 1, 6, 7
+- `aggregateCandles.ts` → Task 4
+- `regimeCandleReadPlan.ts` → Task 5
+- Handler flow → Task 7
+- `buildRegimeCurrent` extension → Task 6
+- Cutoff and no-lookahead rules → Tasks 5 (cutoff math) + 7 (filtering after aggregation)
+- Configuration → Task 3
+- Validation → Task 2
+- Testing plan (aggregation utility, read plan, contract validation, regime-current handler) → Tasks 4, 5, 2, 8
+- Acceptance criteria → "Acceptance Criteria" section above

--- a/docs/superpowers/specs/2026-05-06-derived-1h-candle-aggregation-design.md
+++ b/docs/superpowers/specs/2026-05-06-derived-1h-candle-aggregation-design.md
@@ -1,0 +1,314 @@
+# Derived 1h Candle Aggregation Design
+
+Date: 2026-05-06
+Issue: https://github.com/opsclawd/regime-engine/issues/42
+
+## Purpose
+
+Regime Engine should keep provider-ingested candles canonical at `15m` while allowing the primary market-regime classifier to run on complete derived `1h` candles. The `15m` direct regime read remains available for diagnostics and later early-warning or veto work.
+
+This design adds an on-demand in-memory `1h` derivation path for `GET /v1/regime/current?timeframe=1h`. It does not add derived candle storage and does not re-enable provider-ingested `1h` candles.
+
+## Goals
+
+- Keep `POST /v1/candles` restricted to provider `15m` candles.
+- Widen only the regime-read timeframe contract to `15m | 1h`.
+- Derive complete `1h` candles from stored latest-revision `15m` candles.
+- Classify direct `15m` requests with the `15m` market-regime config.
+- Classify derived `1h` requests with the restored `1h` market-regime config.
+- Exclude incomplete or future current-hour aggregates from classification.
+- Make direct-vs-derived reads observable in the public API response metadata.
+- Keep aggregation deterministic, pure, and reusable for later derived timeframes.
+
+## Non-Goals
+
+- No provider-ingested `1h` candles.
+- No materialized derived candle table or migration.
+- No broad candle read service abstraction.
+- No full multi-timeframe classifier.
+- No `15m` veto or early-warning policy.
+- No on-chain execution logic.
+
+## Public Contract
+
+`CandleIngestTimeframe` remains narrow:
+
+```ts
+export type CandleIngestTimeframe = "15m";
+```
+
+`RegimeReadTimeframe` becomes:
+
+```ts
+export type RegimeReadTimeframe = "15m" | "1h";
+```
+
+`RegimeCurrentResponse.metadata` becomes stricter where values are always known:
+
+```ts
+metadata: {
+  engineVersion: string;
+  configVersion: string;
+  candleCount: number;
+  sourceTimeframe: "15m";
+  sourceCandleCount: number;
+  derivedTimeframe?: "1h";
+  aggregationVersion?: "ohlcv-agg-v1";
+}
+```
+
+For direct `15m` reads:
+
+- `candleCount` is the classified `15m` candle count.
+- `sourceTimeframe` is `"15m"`.
+- `sourceCandleCount` equals `candleCount`.
+- `derivedTimeframe` is omitted.
+- `aggregationVersion` is omitted.
+
+For derived `1h` reads:
+
+- `candleCount` is the derived `1h` candle count used for classification.
+- `sourceTimeframe` is `"15m"`.
+- `sourceCandleCount` is the actual number of `15m` rows returned by the store before aggregation and derived-cutoff filtering.
+- `derivedTimeframe` is `"1h"`.
+- `aggregationVersion` is `"ohlcv-agg-v1"`.
+
+## Components
+
+### `src/engine/candles/aggregateCandles.ts`
+
+A dumb, pure candle math utility.
+
+Responsibilities:
+
+- Accept source candles plus target timeframe.
+- Support `aggregateCandles(candles, "1h")`.
+- Sort input internally by `unixMs`.
+- Aggregate only exact complete `HH:00`, `HH:15`, `HH:30`, `HH:45` source buckets.
+- Skip incomplete buckets.
+- Skip misaligned source candles.
+- Never synthesize missing source candles.
+- Never aggregate across hour boundaries.
+- Emit sorted derived candles.
+
+The utility has no store access, no market-regime config access, no metadata construction, and no logging.
+
+Derived `1h` OHLCV formula:
+
+- `open`: first `15m` open.
+- `high`: maximum high across the four `15m` candles.
+- `low`: minimum low across the four `15m` candles.
+- `close`: last `15m` close.
+- `volume`: sum of volume across the four `15m` candles.
+- `unixMs`: `1h` bucket open timestamp.
+
+### `src/engine/marketRegime/regimeCandleReadPlan.ts`
+
+A tiny pure helper for regime-specific read policy and math.
+
+Responsibilities:
+
+- Decide the stored source timeframe for a requested regime-read timeframe.
+- Compute source read limits.
+- Compute source and derived cutoffs.
+- Return static metadata hints for direct and derived reads. The handler fills count fields after reading and selecting candles.
+
+For direct `15m`, the helper returns:
+
+- `sourceTimeframe: "15m"`
+- `sourceCutoffUnixMs` using the `15m` timeframe and `15m` freshness config.
+- `sourceLimit = max(volLongWindow, minCandles) + READ_BUFFER`
+- no `derivedCutoffUnixMs`
+- direct static metadata hints.
+
+For derived `1h`, the helper returns:
+
+- `sourceTimeframe: "15m"`
+- `sourceCutoffUnixMs` using the `15m` timeframe and `15m` freshness config.
+- `derivedCutoffUnixMs` using the `1h` timeframe and `1h` freshness config.
+- `requiredDerivedBars = max(volLongWindow, minCandles) + READ_BUFFER`
+- `sourceLimit = requiredDerivedBars * 4 + DERIVED_SOURCE_READ_BUFFER_15M`
+- derived static metadata hints.
+
+Constants:
+
+```ts
+const READ_BUFFER = 50;
+const FIFTEEN_MINUTES_PER_HOUR = 4;
+const DERIVED_SOURCE_READ_BUFFER_15M = 32;
+```
+
+### `src/http/handlers/regimeCurrent.ts`
+
+The handler owns orchestration.
+
+Responsibilities:
+
+- Parse and validate the requested regime-read timeframe.
+- Select market-regime config by requested timeframe.
+- Build a regime candle read plan.
+- Read latest-revision source candles from the existing candle store path.
+- For direct `15m`, classify source candles directly.
+- For derived `1h`, aggregate source `15m` candles, filter by derived cutoff, and classify derived candles.
+- Preserve response `timeframe` as the requested timeframe.
+- Pass caller-supplied metadata additions to `buildRegimeCurrent`.
+
+### `src/engine/marketRegime/buildRegimeCurrent.ts`
+
+`buildRegimeCurrent` remains source-agnostic.
+
+It may accept caller-supplied metadata additions, but it must not decide whether the candles are direct or derived. It receives already-selected candles, computes regime response fields, and merges the supplied metadata fields into `metadata`.
+
+## Handler Flow
+
+### Direct `timeframe=15m`
+
+1. Validate the query.
+2. Load `MARKET_REGIME_CONFIG["15m"]`.
+3. Build a read plan for `15m`.
+4. Read stored latest-revision `15m` candles using `sourceCutoffUnixMs` and `sourceLimit`.
+5. If the source read returns zero rows, return existing `CANDLES_NOT_FOUND`.
+6. Call `buildRegimeCurrent` with the source candles and requested feed timeframe `15m`.
+7. Return metadata with `sourceTimeframe: "15m"` and `sourceCandleCount` equal to the classified candle count.
+
+### Derived `timeframe=1h`
+
+1. Validate the query.
+2. Load `MARKET_REGIME_CONFIG["1h"]`.
+3. Build a read plan for `1h`.
+4. Read stored latest-revision `15m` candles using `sourceCutoffUnixMs` and `sourceLimit`.
+5. If the source read returns zero rows, return existing `CANDLES_NOT_FOUND`.
+6. Aggregate complete `1h` candles with `aggregateCandles(sourceCandles, "1h")`.
+7. Filter derived candles with `unixMs <= derivedCutoffUnixMs`.
+8. If filtering leaves zero derived candles, return `CANDLES_NOT_FOUND` with a derived-specific message.
+9. Call `buildRegimeCurrent` with derived candles, requested feed timeframe `1h`, and `MARKET_REGIME_CONFIG["1h"]`.
+10. Return metadata identifying the source and aggregation:
+    - `sourceTimeframe: "15m"`
+    - `sourceCandleCount: sourceCandles.length`
+    - `derivedTimeframe: "1h"`
+    - `aggregationVersion: "ohlcv-agg-v1"`
+
+If derived aggregation/filtering returns nonzero but fewer than `MARKET_REGIME_CONFIG["1h"].suitability.minCandles`, call `buildRegimeCurrent` and let the existing insufficient-samples response behavior apply.
+
+## Cutoff And No-Lookahead Rules
+
+Direct `15m` reads use the `15m` config and the `15m` closed-candle cutoff.
+
+Derived `1h` reads compute two cutoffs:
+
+- `sourceCutoffUnixMs`: based on the `15m` timeframe and `15m` freshness config.
+- `derivedCutoffUnixMs`: based on the `1h` timeframe and `1h` freshness config.
+
+The handler must:
+
+1. Read source `15m` rows up to `sourceCutoffUnixMs`.
+2. Aggregate complete `1h` buckets from source rows.
+3. Filter derived candles with `unixMs <= derivedCutoffUnixMs`.
+4. Classify only the filtered derived candles.
+
+A derived `1h` candle for `HH:00` may use only `HH:00`, `HH:15`, `HH:30`, and `HH:45` source candles. It must not use future candles and must not be emitted unless the full bucket exists.
+
+## Configuration
+
+`MARKET_REGIME_CONFIG` should become:
+
+```ts
+export const MARKET_REGIME_CONFIG: Record<RegimeReadTimeframe, MarketTimeframeConfig> = {
+  "15m": {
+    // existing post-#41 15m config
+  },
+  "1h": {
+    // restored 1h config
+  }
+};
+```
+
+`MarketTimeframeConfig.timeframe` should use `RegimeReadTimeframe`.
+
+The `15m` config remains the post-#41 direct diagnostic config. The `1h` config is restored for primary market-regime classification.
+
+## Validation
+
+Validation remains split:
+
+```ts
+const CANDLE_INGEST_TIMEFRAMES = ["15m"] as const;
+const REGIME_READ_TIMEFRAMES = ["15m", "1h"] as const;
+```
+
+Required behavior:
+
+- `POST /v1/candles` accepts `timeframe: "15m"`.
+- `POST /v1/candles` rejects `timeframe: "1h"`.
+- `GET /v1/regime/current?timeframe=15m` validates.
+- `GET /v1/regime/current?timeframe=1h` validates.
+- Unsupported regime-read timeframes still reject.
+
+No shared vague `SupportedTimeframe` should be introduced.
+
+## Testing Plan
+
+### Aggregation Utility
+
+Add tests under `src/engine/candles/__tests__/aggregateCandles.test.ts`:
+
+- Four aligned `15m` candles produce one `1h` candle.
+- Open, high, low, close, and volume are correct.
+- Output `unixMs` is the `1h` bucket open timestamp.
+- Input order does not matter.
+- Output is sorted ascending.
+- Incomplete buckets are skipped.
+- Missing middle candles skip the bucket.
+- Misaligned source timestamps are skipped.
+- Aggregation never crosses hour boundaries.
+
+### Read Plan
+
+Add tests under `src/engine/marketRegime/__tests__/regimeCandleReadPlan.test.ts`:
+
+- Direct `15m` uses source timeframe `15m`.
+- Direct `15m` computes source cutoff from the `15m` config.
+- Direct `15m` uses `max(volLongWindow, minCandles) + READ_BUFFER`.
+- Derived `1h` uses source timeframe `15m`.
+- Derived `1h` computes `sourceCutoffUnixMs` from the `15m` config.
+- Derived `1h` computes `derivedCutoffUnixMs` from the `1h` config.
+- Derived `1h` computes `sourceLimit = requiredDerivedBars * 4 + DERIVED_SOURCE_READ_BUFFER_15M`.
+- Metadata hints match direct and derived reads.
+
+### Contract Validation
+
+Update validation tests:
+
+- `POST /v1/candles` still accepts `15m`.
+- `POST /v1/candles` still rejects `1h`.
+- `GET /v1/regime/current?timeframe=15m` accepts.
+- `GET /v1/regime/current?timeframe=1h` accepts.
+- Unsupported regime-read timeframes still reject.
+
+### Regime Current Handler
+
+Update e2e tests:
+
+- Direct `15m` reads stored `15m` candles and returns `timeframe: "15m"`.
+- Direct `15m` metadata includes `sourceTimeframe: "15m"` and `sourceCandleCount === candleCount`.
+- Derived `1h` reads stored `15m` candles and returns `timeframe: "1h"`.
+- Derived `1h` classifies with `MARKET_REGIME_CONFIG["1h"]`.
+- Derived `1h` metadata includes `sourceTimeframe`, `sourceCandleCount`, `derivedTimeframe`, and `aggregationVersion`.
+- Derived path excludes incomplete current-hour buckets.
+- Derived zero usable candles returns `CANDLES_NOT_FOUND`.
+- Derived nonzero-but-insufficient candles uses existing insufficient-samples behavior.
+- Latest-revision duplicate handling occurs through the existing store query before aggregation.
+
+## Acceptance Criteria
+
+- `CandleIngestTimeframe` remains `"15m"`.
+- `RegimeReadTimeframe` becomes `"15m" | "1h"`.
+- Provider ingestion remains `15m` only.
+- `GET /v1/regime/current?timeframe=1h` derives complete `1h` candles from stored latest-revision `15m` rows.
+- Incomplete current-hour aggregates are not classified.
+- Missing source buckets are not synthesized.
+- Classification uses the config for the requested regime-read timeframe.
+- Response timeframe remains the requested timeframe.
+- Metadata makes direct-vs-derived reads observable.
+- No database storage or migration is added for derived candles.
+- No provider `1h` ingestion path is added.

--- a/src/contract/v1/__tests__/regimeCurrent.validation.test.ts
+++ b/src/contract/v1/__tests__/regimeCurrent.validation.test.ts
@@ -30,10 +30,20 @@ describe("parseRegimeCurrentQuery", () => {
     }
   );
 
-  it("rejects timeframe=1h until #42", () => {
+  it("accepts timeframe=15m", () => {
+    const result = parseRegimeCurrentQuery({ ...baseQuery, timeframe: "15m" });
+    expect(result.timeframe).toBe("15m");
+  });
+
+  it("accepts timeframe=1h", () => {
+    const result = parseRegimeCurrentQuery({ ...baseQuery, timeframe: "1h" });
+    expect(result.timeframe).toBe("1h");
+  });
+
+  it("rejects unsupported regime-read timeframe (e.g. 4h) with VALIDATION_ERROR", () => {
     expect.assertions(1);
     try {
-      parseRegimeCurrentQuery({ ...baseQuery, timeframe: "1h" });
+      parseRegimeCurrentQuery({ ...baseQuery, timeframe: "4h" });
     } catch (error) {
       expect((error as ContractValidationError).response.error.code).toBe("VALIDATION_ERROR");
     }

--- a/src/contract/v1/types.ts
+++ b/src/contract/v1/types.ts
@@ -223,7 +223,7 @@ export interface SrLevelsCurrentResponse {
 }
 
 export type CandleIngestTimeframe = "15m";
-export type RegimeReadTimeframe = "15m";
+export type RegimeReadTimeframe = "15m" | "1h";
 
 export type ClmmSuitabilityStatus = "ALLOWED" | "CAUTION" | "BLOCKED" | "UNKNOWN";
 
@@ -307,6 +307,10 @@ export interface RegimeCurrentMetadata {
   engineVersion: string;
   configVersion: string;
   candleCount: number;
+  sourceTimeframe: "15m";
+  sourceCandleCount: number;
+  derivedTimeframe?: "1h";
+  aggregationVersion?: "ohlcv-agg-v1";
 }
 
 export interface RegimeCurrentResponse {

--- a/src/contract/v1/types.ts
+++ b/src/contract/v1/types.ts
@@ -244,6 +244,7 @@ export interface GetLatestCandlesParams {
   network: string;
   poolAddress: string;
   timeframe: string;
+  timeframeMs: number;
   closedCandleCutoffUnixMs: number;
   limit: number;
 }
@@ -307,10 +308,10 @@ export interface RegimeCurrentMetadata {
   engineVersion: string;
   configVersion: string;
   candleCount: number;
-  sourceTimeframe: "15m";
+  sourceTimeframe: string;
   sourceCandleCount: number;
-  derivedTimeframe?: "1h";
-  aggregationVersion?: "ohlcv-agg-v1";
+  derivedTimeframe?: string;
+  aggregationVersion?: string;
 }
 
 export interface RegimeCurrentResponse {

--- a/src/contract/v1/types.ts
+++ b/src/contract/v1/types.ts
@@ -244,7 +244,6 @@ export interface GetLatestCandlesParams {
   network: string;
   poolAddress: string;
   timeframe: string;
-  timeframeMs: number;
   closedCandleCutoffUnixMs: number;
   limit: number;
 }

--- a/src/contract/v1/validation.ts
+++ b/src/contract/v1/validation.ts
@@ -14,6 +14,7 @@ import {
   type ClmmExecutionEventRequest,
   type ExecutionResultRequest,
   type PlanRequest,
+  type RegimeReadTimeframe,
   type SrLevelBriefRequest
 } from "./types.js";
 
@@ -278,7 +279,7 @@ export const parseClmmExecutionEventRequest = (raw: unknown): ClmmExecutionEvent
 };
 
 const CANDLE_INGEST_TIMEFRAMES = ["15m"] as const;
-const REGIME_READ_TIMEFRAMES = ["15m"] as const;
+const REGIME_READ_TIMEFRAMES = ["15m", "1h"] as const;
 
 const CANDLE_INGEST_TIMEFRAME_TO_MS: Record<CandleIngestTimeframe, number> = {
   "15m": 15 * 60 * 1000
@@ -422,7 +423,7 @@ export const parseRegimeCurrentQuery = (
   source: string;
   network: string;
   poolAddress: string;
-  timeframe: "15m";
+  timeframe: RegimeReadTimeframe;
 } => {
   const parsed = regimeCurrentQuerySchema.safeParse(raw);
   if (!parsed.success) {

--- a/src/engine/candles/__tests__/aggregateCandles.test.ts
+++ b/src/engine/candles/__tests__/aggregateCandles.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Candle } from "../../../contract/v1/types.js";
-import { aggregateCandles } from "../aggregateCandles.js";
-
-const FIFTEEN_MIN_MS = 15 * 60 * 1000;
-const ONE_HOUR_MS = 60 * 60 * 1000;
+import { aggregate15mTo1h, FIFTEEN_MIN_MS, ONE_HOUR_MS } from "../aggregateCandles.js";
 
 const makeCandle = (unixMs: number, overrides: Partial<Candle> = {}): Candle => ({
   unixMs,
@@ -40,56 +37,65 @@ const fourAlignedCandles = (hourOpenUnixMs: number): Candle[] => [
   })
 ];
 
-describe("aggregateCandles 1h", () => {
+describe("aggregate15mTo1h", () => {
   it("aggregates four aligned 15m candles into one 1h candle", () => {
     const hourOpen = 12 * ONE_HOUR_MS;
-    const result = aggregateCandles(fourAlignedCandles(hourOpen), "1h");
-    expect(result).toHaveLength(1);
-    expect(result[0].unixMs).toBe(hourOpen);
-    expect(result[0].open).toBe(100);
-    expect(result[0].high).toBe(107);
-    expect(result[0].low).toBe(98);
-    expect(result[0].close).toBe(103);
-    expect(result[0].volume).toBe(22);
+    const { candles, telemetry } = aggregate15mTo1h(fourAlignedCandles(hourOpen));
+    expect(candles).toHaveLength(1);
+    expect(candles[0].unixMs).toBe(hourOpen);
+    expect(candles[0].open).toBe(100);
+    expect(candles[0].high).toBe(107);
+    expect(candles[0].low).toBe(98);
+    expect(candles[0].close).toBe(103);
+    expect(candles[0].volume).toBe(22);
+    expect(telemetry.sourceCandleCount).toBe(4);
+    expect(telemetry.completeBuckets).toBe(1);
+    expect(telemetry.skippedNonInteger).toBe(0);
+    expect(telemetry.skippedMisaligned).toBe(0);
+    expect(telemetry.skippedIncomplete).toBe(0);
+    expect(telemetry.skippedGapInBucket).toBe(0);
   });
 
   it("emits the 1h bucket open timestamp", () => {
     const hourOpen = 100 * ONE_HOUR_MS;
-    const result = aggregateCandles(fourAlignedCandles(hourOpen), "1h");
-    expect(result[0].unixMs).toBe(hourOpen);
+    const { candles } = aggregate15mTo1h(fourAlignedCandles(hourOpen));
+    expect(candles[0].unixMs).toBe(hourOpen);
   });
 
   it("treats input order as irrelevant and emits sorted output", () => {
     const a = fourAlignedCandles(2 * ONE_HOUR_MS);
     const b = fourAlignedCandles(1 * ONE_HOUR_MS);
     const shuffled = [a[2], b[3], a[0], b[1], a[3], b[0], a[1], b[2]];
-    const result = aggregateCandles(shuffled, "1h");
-    expect(result).toHaveLength(2);
-    expect(result[0].unixMs).toBe(1 * ONE_HOUR_MS);
-    expect(result[1].unixMs).toBe(2 * ONE_HOUR_MS);
+    const { candles } = aggregate15mTo1h(shuffled);
+    expect(candles).toHaveLength(2);
+    expect(candles[0].unixMs).toBe(1 * ONE_HOUR_MS);
+    expect(candles[1].unixMs).toBe(2 * ONE_HOUR_MS);
   });
 
   it("skips an incomplete current-hour bucket (only 3 candles present)", () => {
     const hourOpen = 5 * ONE_HOUR_MS;
     const partial = fourAlignedCandles(hourOpen).slice(0, 3);
-    const result = aggregateCandles(partial, "1h");
-    expect(result).toHaveLength(0);
+    const { candles, telemetry } = aggregate15mTo1h(partial);
+    expect(candles).toHaveLength(0);
+    expect(telemetry.skippedIncomplete).toBe(1);
   });
 
-  it("skips a bucket missing a middle candle", () => {
+  it("skips a bucket with 4 candles that have a gap in position", () => {
     const hourOpen = 5 * ONE_HOUR_MS;
     const four = fourAlignedCandles(hourOpen);
-    const missingMiddle = [four[0], four[1], four[3]];
-    const result = aggregateCandles(missingMiddle, "1h");
-    expect(result).toHaveLength(0);
+    const gapped = [four[0], four[1], four[1], four[3]];
+    const { candles, telemetry } = aggregate15mTo1h(gapped);
+    expect(candles).toHaveLength(0);
+    expect(telemetry.skippedGapInBucket).toBe(1);
   });
 
   it("ignores misaligned source timestamps", () => {
     const hourOpen = 5 * ONE_HOUR_MS;
     const four = fourAlignedCandles(hourOpen);
     const misaligned = [four[0], makeCandle(hourOpen + FIFTEEN_MIN_MS + 60_000), four[2], four[3]];
-    const result = aggregateCandles(misaligned, "1h");
-    expect(result).toHaveLength(0);
+    const { candles, telemetry } = aggregate15mTo1h(misaligned);
+    expect(candles).toHaveLength(0);
+    expect(telemetry.skippedMisaligned).toBe(1);
   });
 
   it("does not aggregate across hour boundaries", () => {
@@ -97,21 +103,39 @@ describe("aggregateCandles 1h", () => {
     const hourOpenB = 6 * ONE_HOUR_MS;
     const incompleteA = fourAlignedCandles(hourOpenA).slice(0, 2);
     const incompleteB = fourAlignedCandles(hourOpenB).slice(2, 4);
-    const result = aggregateCandles([...incompleteA, ...incompleteB], "1h");
-    expect(result).toHaveLength(0);
+    const { candles } = aggregate15mTo1h([...incompleteA, ...incompleteB]);
+    expect(candles).toHaveLength(0);
   });
 
   it("emits multiple complete buckets independently", () => {
-    const result = aggregateCandles(
-      [...fourAlignedCandles(0), ...fourAlignedCandles(ONE_HOUR_MS)],
-      "1h"
-    );
-    expect(result).toHaveLength(2);
-    expect(result[0].unixMs).toBe(0);
-    expect(result[1].unixMs).toBe(ONE_HOUR_MS);
+    const { candles } = aggregate15mTo1h([
+      ...fourAlignedCandles(0),
+      ...fourAlignedCandles(ONE_HOUR_MS)
+    ]);
+    expect(candles).toHaveLength(2);
+    expect(candles[0].unixMs).toBe(0);
+    expect(candles[1].unixMs).toBe(ONE_HOUR_MS);
   });
 
   it("returns an empty array for an empty input", () => {
-    expect(aggregateCandles([], "1h")).toEqual([]);
+    const { candles, telemetry } = aggregate15mTo1h([]);
+    expect(candles).toEqual([]);
+    expect(telemetry.sourceCandleCount).toBe(0);
+  });
+
+  it("skips candles with non-integer unixMs timestamps", () => {
+    const hourOpen = 5 * ONE_HOUR_MS;
+    const four = fourAlignedCandles(hourOpen);
+    const withNonInteger = [
+      makeCandle(hourOpen + 0.5, { volume: 10 }),
+      four[0],
+      four[1],
+      four[2],
+      four[3]
+    ];
+    const { candles, telemetry } = aggregate15mTo1h(withNonInteger);
+    expect(candles).toHaveLength(1);
+    expect(telemetry.skippedNonInteger).toBe(1);
+    expect(telemetry.sourceCandleCount).toBe(5);
   });
 });

--- a/src/engine/candles/__tests__/aggregateCandles.test.ts
+++ b/src/engine/candles/__tests__/aggregateCandles.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import type { Candle } from "../../../contract/v1/types.js";
+import { aggregateCandles } from "../aggregateCandles.js";
+
+const FIFTEEN_MIN_MS = 15 * 60 * 1000;
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+const makeCandle = (unixMs: number, overrides: Partial<Candle> = {}): Candle => ({
+  unixMs,
+  open: 100,
+  high: 101,
+  low: 99,
+  close: 100.5,
+  volume: 1,
+  ...overrides
+});
+
+const fourAlignedCandles = (hourOpenUnixMs: number): Candle[] => [
+  makeCandle(hourOpenUnixMs, { open: 100, high: 102, low: 98, close: 101, volume: 5 }),
+  makeCandle(hourOpenUnixMs + FIFTEEN_MIN_MS, {
+    open: 101,
+    high: 105,
+    low: 100,
+    close: 104,
+    volume: 7
+  }),
+  makeCandle(hourOpenUnixMs + 2 * FIFTEEN_MIN_MS, {
+    open: 104,
+    high: 106,
+    low: 103,
+    close: 105,
+    volume: 4
+  }),
+  makeCandle(hourOpenUnixMs + 3 * FIFTEEN_MIN_MS, {
+    open: 105,
+    high: 107,
+    low: 102,
+    close: 103,
+    volume: 6
+  })
+];
+
+describe("aggregateCandles 1h", () => {
+  it("aggregates four aligned 15m candles into one 1h candle", () => {
+    const hourOpen = 12 * ONE_HOUR_MS;
+    const result = aggregateCandles(fourAlignedCandles(hourOpen), "1h");
+    expect(result).toHaveLength(1);
+    expect(result[0].unixMs).toBe(hourOpen);
+    expect(result[0].open).toBe(100);
+    expect(result[0].high).toBe(107);
+    expect(result[0].low).toBe(98);
+    expect(result[0].close).toBe(103);
+    expect(result[0].volume).toBe(22);
+  });
+
+  it("emits the 1h bucket open timestamp", () => {
+    const hourOpen = 100 * ONE_HOUR_MS;
+    const result = aggregateCandles(fourAlignedCandles(hourOpen), "1h");
+    expect(result[0].unixMs).toBe(hourOpen);
+  });
+
+  it("treats input order as irrelevant and emits sorted output", () => {
+    const a = fourAlignedCandles(2 * ONE_HOUR_MS);
+    const b = fourAlignedCandles(1 * ONE_HOUR_MS);
+    const shuffled = [a[2], b[3], a[0], b[1], a[3], b[0], a[1], b[2]];
+    const result = aggregateCandles(shuffled, "1h");
+    expect(result).toHaveLength(2);
+    expect(result[0].unixMs).toBe(1 * ONE_HOUR_MS);
+    expect(result[1].unixMs).toBe(2 * ONE_HOUR_MS);
+  });
+
+  it("skips an incomplete current-hour bucket (only 3 candles present)", () => {
+    const hourOpen = 5 * ONE_HOUR_MS;
+    const partial = fourAlignedCandles(hourOpen).slice(0, 3);
+    const result = aggregateCandles(partial, "1h");
+    expect(result).toHaveLength(0);
+  });
+
+  it("skips a bucket missing a middle candle", () => {
+    const hourOpen = 5 * ONE_HOUR_MS;
+    const four = fourAlignedCandles(hourOpen);
+    const missingMiddle = [four[0], four[1], four[3]];
+    const result = aggregateCandles(missingMiddle, "1h");
+    expect(result).toHaveLength(0);
+  });
+
+  it("ignores misaligned source timestamps", () => {
+    const hourOpen = 5 * ONE_HOUR_MS;
+    const four = fourAlignedCandles(hourOpen);
+    const misaligned = [four[0], makeCandle(hourOpen + FIFTEEN_MIN_MS + 60_000), four[2], four[3]];
+    const result = aggregateCandles(misaligned, "1h");
+    expect(result).toHaveLength(0);
+  });
+
+  it("does not aggregate across hour boundaries", () => {
+    const hourOpenA = 5 * ONE_HOUR_MS;
+    const hourOpenB = 6 * ONE_HOUR_MS;
+    const incompleteA = fourAlignedCandles(hourOpenA).slice(0, 2);
+    const incompleteB = fourAlignedCandles(hourOpenB).slice(2, 4);
+    const result = aggregateCandles([...incompleteA, ...incompleteB], "1h");
+    expect(result).toHaveLength(0);
+  });
+
+  it("emits multiple complete buckets independently", () => {
+    const result = aggregateCandles(
+      [...fourAlignedCandles(0), ...fourAlignedCandles(ONE_HOUR_MS)],
+      "1h"
+    );
+    expect(result).toHaveLength(2);
+    expect(result[0].unixMs).toBe(0);
+    expect(result[1].unixMs).toBe(ONE_HOUR_MS);
+  });
+
+  it("returns an empty array for an empty input", () => {
+    expect(aggregateCandles([], "1h")).toEqual([]);
+  });
+});

--- a/src/engine/candles/aggregateCandles.ts
+++ b/src/engine/candles/aggregateCandles.ts
@@ -4,32 +4,46 @@ const FIFTEEN_MIN_MS = 15 * 60 * 1000;
 const ONE_HOUR_MS = 60 * 60 * 1000;
 const FIFTEEN_MINUTES_PER_HOUR = 4;
 
-type AggregationTargetTimeframe = "1h";
+export { FIFTEEN_MIN_MS, ONE_HOUR_MS, FIFTEEN_MINUTES_PER_HOUR };
 
-const targetBucketMs: Record<AggregationTargetTimeframe, number> = {
-  "1h": ONE_HOUR_MS
-};
+export interface AggregationTelemetry {
+  sourceCandleCount: number;
+  skippedNonInteger: number;
+  skippedMisaligned: number;
+  skippedIncomplete: number;
+  skippedGapInBucket: number;
+  completeBuckets: number;
+}
 
-const sourceTimeframeMs: Record<AggregationTargetTimeframe, number> = {
-  "1h": FIFTEEN_MIN_MS
-};
+export interface Aggregate15mTo1hResult {
+  candles: Candle[];
+  telemetry: AggregationTelemetry;
+}
 
-const sourceCountPerBucket: Record<AggregationTargetTimeframe, number> = {
-  "1h": FIFTEEN_MINUTES_PER_HOUR
-};
+export const aggregate15mTo1h = (candles: Candle[]): Aggregate15mTo1hResult => {
+  const bucketMs = ONE_HOUR_MS;
+  const srcMs = FIFTEEN_MIN_MS;
+  const required = FIFTEEN_MINUTES_PER_HOUR;
 
-export const aggregateCandles = (
-  candles: Candle[],
-  target: AggregationTargetTimeframe
-): Candle[] => {
-  const bucketMs = targetBucketMs[target];
-  const srcMs = sourceTimeframeMs[target];
-  const required = sourceCountPerBucket[target];
+  const telemetry: AggregationTelemetry = {
+    sourceCandleCount: candles.length,
+    skippedNonInteger: 0,
+    skippedMisaligned: 0,
+    skippedIncomplete: 0,
+    skippedGapInBucket: 0,
+    completeBuckets: 0
+  };
 
   const buckets = new Map<number, Candle[]>();
   for (const candle of candles) {
-    if (!Number.isInteger(candle.unixMs)) continue;
-    if (candle.unixMs % srcMs !== 0) continue;
+    if (!Number.isInteger(candle.unixMs)) {
+      telemetry.skippedNonInteger += 1;
+      continue;
+    }
+    if (candle.unixMs % srcMs !== 0) {
+      telemetry.skippedMisaligned += 1;
+      continue;
+    }
 
     const bucketOpen = Math.floor(candle.unixMs / bucketMs) * bucketMs;
     const list = buckets.get(bucketOpen);
@@ -42,7 +56,10 @@ export const aggregateCandles = (
 
   const out: Candle[] = [];
   for (const [bucketOpen, sources] of buckets) {
-    if (sources.length !== required) continue;
+    if (sources.length !== required) {
+      telemetry.skippedIncomplete += 1;
+      continue;
+    }
 
     sources.sort((a, b) => a.unixMs - b.unixMs);
 
@@ -53,7 +70,12 @@ export const aggregateCandles = (
         break;
       }
     }
-    if (!complete) continue;
+    if (!complete) {
+      telemetry.skippedGapInBucket += 1;
+      continue;
+    }
+
+    telemetry.completeBuckets += 1;
 
     let high = sources[0].high;
     let low = sources[0].low;
@@ -75,5 +97,5 @@ export const aggregateCandles = (
   }
 
   out.sort((a, b) => a.unixMs - b.unixMs);
-  return out;
+  return { candles: out, telemetry };
 };

--- a/src/engine/candles/aggregateCandles.ts
+++ b/src/engine/candles/aggregateCandles.ts
@@ -1,0 +1,79 @@
+import type { Candle } from "../../contract/v1/types.js";
+
+const FIFTEEN_MIN_MS = 15 * 60 * 1000;
+const ONE_HOUR_MS = 60 * 60 * 1000;
+const FIFTEEN_MINUTES_PER_HOUR = 4;
+
+type AggregationTargetTimeframe = "1h";
+
+const targetBucketMs: Record<AggregationTargetTimeframe, number> = {
+  "1h": ONE_HOUR_MS
+};
+
+const sourceTimeframeMs: Record<AggregationTargetTimeframe, number> = {
+  "1h": FIFTEEN_MIN_MS
+};
+
+const sourceCountPerBucket: Record<AggregationTargetTimeframe, number> = {
+  "1h": FIFTEEN_MINUTES_PER_HOUR
+};
+
+export const aggregateCandles = (
+  candles: Candle[],
+  target: AggregationTargetTimeframe
+): Candle[] => {
+  const bucketMs = targetBucketMs[target];
+  const srcMs = sourceTimeframeMs[target];
+  const required = sourceCountPerBucket[target];
+
+  const buckets = new Map<number, Candle[]>();
+  for (const candle of candles) {
+    if (!Number.isInteger(candle.unixMs)) continue;
+    if (candle.unixMs % srcMs !== 0) continue;
+
+    const bucketOpen = Math.floor(candle.unixMs / bucketMs) * bucketMs;
+    const list = buckets.get(bucketOpen);
+    if (list) {
+      list.push(candle);
+    } else {
+      buckets.set(bucketOpen, [candle]);
+    }
+  }
+
+  const out: Candle[] = [];
+  for (const [bucketOpen, sources] of buckets) {
+    if (sources.length !== required) continue;
+
+    sources.sort((a, b) => a.unixMs - b.unixMs);
+
+    let complete = true;
+    for (let i = 0; i < required; i += 1) {
+      if (sources[i].unixMs !== bucketOpen + i * srcMs) {
+        complete = false;
+        break;
+      }
+    }
+    if (!complete) continue;
+
+    let high = sources[0].high;
+    let low = sources[0].low;
+    let volume = 0;
+    for (const src of sources) {
+      if (src.high > high) high = src.high;
+      if (src.low < low) low = src.low;
+      volume += src.volume;
+    }
+
+    out.push({
+      unixMs: bucketOpen,
+      open: sources[0].open,
+      high,
+      low,
+      close: sources[required - 1].close,
+      volume
+    });
+  }
+
+  out.sort((a, b) => a.unixMs - b.unixMs);
+  return out;
+};

--- a/src/engine/marketRegime/__tests__/__snapshots__/buildRegimeCurrent.snapshot.test.ts.snap
+++ b/src/engine/marketRegime/__tests__/__snapshots__/buildRegimeCurrent.snapshot.test.ts.snap
@@ -1,6 +1,71 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`buildRegimeCurrent snapshot > produces identical response objects for fixed inputs 1`] = `
+exports[`buildRegimeCurrent snapshot > produces identical response objects for fixed 1h derived inputs 1`] = `
+{
+  "clmmSuitability": {
+    "reasons": [
+      {
+        "code": "CLMM_UNKNOWN_HARD_STALE_DATA",
+        "message": "Latest candle exceeds hard-stale window; classification is not trustworthy.",
+        "severity": "ERROR",
+      },
+    ],
+    "status": "UNKNOWN",
+  },
+  "freshness": {
+    "ageSeconds": 68400,
+    "generatedAtIso": "1970-01-03T02:00:00.000Z",
+    "hardStale": true,
+    "hardStaleSeconds": 5400,
+    "lastCandleIso": "1970-01-02T07:00:00.000Z",
+    "lastCandleUnixMs": 111600000,
+    "softStale": true,
+    "softStaleSeconds": 4500,
+  },
+  "marketReasons": [
+    {
+      "code": "REGIME_STABLE",
+      "message": "Current telemetry holds CHOP regime.",
+      "severity": "INFO",
+    },
+    {
+      "code": "DATA_HARD_STALE",
+      "message": "Latest candle is older than the hard-stale window.",
+      "severity": "ERROR",
+    },
+    {
+      "code": "DATA_SUFFICIENT_SAMPLES",
+      "message": "Have 31 closed candles (>= 30).",
+      "severity": "INFO",
+    },
+  ],
+  "metadata": {
+    "aggregationVersion": "ohlcv-agg-v1",
+    "candleCount": 31,
+    "configVersion": "market-regime-2.0.0",
+    "derivedTimeframe": "1h",
+    "engineVersion": "0.1.0",
+    "sourceCandleCount": 130,
+    "sourceTimeframe": "15m",
+  },
+  "network": "solana-mainnet",
+  "poolAddress": "Pool111",
+  "regime": "CHOP",
+  "schemaVersion": "1.0",
+  "source": "birdeye",
+  "symbol": "SOL/USDC",
+  "telemetry": {
+    "compression": 0.084759302487,
+    "realizedVolLong": 0.00037790518,
+    "realizedVolShort": 0.000084095413,
+    "trendStrength": 0.003634711495,
+    "volRatio": 0.360540549177,
+  },
+  "timeframe": "1h",
+}
+`;
+
+exports[`buildRegimeCurrent snapshot > produces identical response objects for fixed 15m inputs 1`] = `
 {
   "clmmSuitability": {
     "reasons": [

--- a/src/engine/marketRegime/__tests__/__snapshots__/buildRegimeCurrent.snapshot.test.ts.snap
+++ b/src/engine/marketRegime/__tests__/__snapshots__/buildRegimeCurrent.snapshot.test.ts.snap
@@ -43,6 +43,8 @@ exports[`buildRegimeCurrent snapshot > produces identical response objects for f
     "candleCount": 130,
     "configVersion": "market-regime-2.0.0",
     "engineVersion": "0.1.0",
+    "sourceCandleCount": 130,
+    "sourceTimeframe": "15m",
   },
   "network": "solana-mainnet",
   "poolAddress": "Pool111",

--- a/src/engine/marketRegime/__tests__/buildRegimeCurrent.snapshot.test.ts
+++ b/src/engine/marketRegime/__tests__/buildRegimeCurrent.snapshot.test.ts
@@ -27,7 +27,11 @@ describe("buildRegimeCurrent snapshot", () => {
       nowUnixMs: 200 * FIFTEEN_MIN_MS,
       config: MARKET_REGIME_CONFIG["15m"],
       configVersion: MARKET_REGIME_CONFIG_VERSION,
-      engineVersion: "0.1.0"
+      engineVersion: "0.1.0",
+      metadata: {
+        sourceTimeframe: "15m",
+        sourceCandleCount: goldenCandles.length
+      }
     });
 
     expect(response).toMatchSnapshot();

--- a/src/engine/marketRegime/__tests__/buildRegimeCurrent.snapshot.test.ts
+++ b/src/engine/marketRegime/__tests__/buildRegimeCurrent.snapshot.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { buildRegimeCurrent } from "../buildRegimeCurrent.js";
 import { MARKET_REGIME_CONFIG, MARKET_REGIME_CONFIG_VERSION } from "../config.js";
+import { aggregate15mTo1h } from "../../candles/aggregateCandles.js";
 
 const FIFTEEN_MIN_MS = 15 * 60 * 1000;
 
@@ -14,7 +15,7 @@ const goldenCandles = Array.from({ length: 130 }, (_, i) => ({
 }));
 
 describe("buildRegimeCurrent snapshot", () => {
-  it("produces identical response objects for fixed inputs", () => {
+  it("produces identical response objects for fixed 15m inputs", () => {
     const response = buildRegimeCurrent({
       feed: {
         symbol: "SOL/USDC",
@@ -31,6 +32,33 @@ describe("buildRegimeCurrent snapshot", () => {
       metadata: {
         sourceTimeframe: "15m",
         sourceCandleCount: goldenCandles.length
+      }
+    });
+
+    expect(response).toMatchSnapshot();
+  });
+
+  it("produces identical response objects for fixed 1h derived inputs", () => {
+    const { candles: aggregated1h } = aggregate15mTo1h(goldenCandles);
+
+    const response = buildRegimeCurrent({
+      feed: {
+        symbol: "SOL/USDC",
+        source: "birdeye",
+        network: "solana-mainnet",
+        poolAddress: "Pool111",
+        timeframe: "1h"
+      },
+      candles: aggregated1h,
+      nowUnixMs: 200 * FIFTEEN_MIN_MS,
+      config: MARKET_REGIME_CONFIG["1h"],
+      configVersion: MARKET_REGIME_CONFIG_VERSION,
+      engineVersion: "0.1.0",
+      metadata: {
+        sourceTimeframe: "15m",
+        sourceCandleCount: goldenCandles.length,
+        derivedTimeframe: "1h",
+        aggregationVersion: "ohlcv-agg-v1"
       }
     });
 

--- a/src/engine/marketRegime/__tests__/buildRegimeCurrent.test.ts
+++ b/src/engine/marketRegime/__tests__/buildRegimeCurrent.test.ts
@@ -13,6 +13,8 @@ const flatCandles = Array.from({ length: 130 }, (_, i) => ({
   volume: 1
 }));
 
+const fewCandles = flatCandles.slice(0, 5);
+
 const feed = {
   symbol: "SOL/USDC",
   source: "birdeye",
@@ -24,14 +26,14 @@ const feed = {
 describe("buildRegimeCurrent", () => {
   it("classifies CHOP and emits ALLOWED for flat candles + fresh data", () => {
     const lastCandleUnixMs = flatCandles[flatCandles.length - 1].unixMs;
-    const nowUnixMs = lastCandleUnixMs + 20 * 60 * 1000;
     const response = buildRegimeCurrent({
       feed,
       candles: flatCandles,
-      nowUnixMs,
+      nowUnixMs: lastCandleUnixMs + 20 * 60 * 1000,
       config: MARKET_REGIME_CONFIG["15m"],
       configVersion: "market-regime-1.0.0",
-      engineVersion: "0.1.0"
+      engineVersion: "0.1.0",
+      metadata: { sourceTimeframe: "15m", sourceCandleCount: flatCandles.length }
     });
 
     expect(response.regime).toBe("CHOP");
@@ -43,7 +45,6 @@ describe("buildRegimeCurrent", () => {
   });
 
   it("returns UNKNOWN when candleCount < minCandles even for fresh data", () => {
-    const fewCandles = flatCandles.slice(0, 5);
     const lastCandleUnixMs = fewCandles[fewCandles.length - 1].unixMs;
     const response = buildRegimeCurrent({
       feed,
@@ -51,7 +52,8 @@ describe("buildRegimeCurrent", () => {
       nowUnixMs: lastCandleUnixMs + 20 * 60 * 1000,
       config: MARKET_REGIME_CONFIG["15m"],
       configVersion: "market-regime-1.0.0",
-      engineVersion: "0.1.0"
+      engineVersion: "0.1.0",
+      metadata: { sourceTimeframe: "15m", sourceCandleCount: fewCandles.length }
     });
     expect(response.clmmSuitability.status).toBe("UNKNOWN");
     expect(response.marketReasons.map((r) => r.code)).toContain("DATA_INSUFFICIENT_SAMPLES");
@@ -65,9 +67,54 @@ describe("buildRegimeCurrent", () => {
       nowUnixMs: lastCandleUnixMs + 40 * 60 * 1000,
       config: MARKET_REGIME_CONFIG["15m"],
       configVersion: "market-regime-1.0.0",
-      engineVersion: "0.1.0"
+      engineVersion: "0.1.0",
+      metadata: { sourceTimeframe: "15m", sourceCandleCount: flatCandles.length }
     });
     expect(response.clmmSuitability.status).toBe("UNKNOWN");
     expect(response.marketReasons.map((r) => r.code)).toContain("DATA_HARD_STALE");
+  });
+
+  it("merges caller-supplied source/derived metadata fields into the response", () => {
+    const lastCandleUnixMs = flatCandles[flatCandles.length - 1].unixMs;
+    const response = buildRegimeCurrent({
+      feed: { ...feed, timeframe: "1h" as const },
+      candles: flatCandles,
+      nowUnixMs: lastCandleUnixMs + 20 * 60 * 1000,
+      config: MARKET_REGIME_CONFIG["1h"],
+      configVersion: "market-regime-2.0.0",
+      engineVersion: "0.1.0",
+      metadata: {
+        sourceTimeframe: "15m",
+        sourceCandleCount: 520,
+        derivedTimeframe: "1h",
+        aggregationVersion: "ohlcv-agg-v1"
+      }
+    });
+    expect(response.timeframe).toBe("1h");
+    expect(response.metadata.sourceTimeframe).toBe("15m");
+    expect(response.metadata.sourceCandleCount).toBe(520);
+    expect(response.metadata.derivedTimeframe).toBe("1h");
+    expect(response.metadata.aggregationVersion).toBe("ohlcv-agg-v1");
+    expect(response.metadata.candleCount).toBe(130);
+  });
+
+  it("omits derived metadata fields when caller provides only source fields", () => {
+    const lastCandleUnixMs = flatCandles[flatCandles.length - 1].unixMs;
+    const response = buildRegimeCurrent({
+      feed,
+      candles: flatCandles,
+      nowUnixMs: lastCandleUnixMs + 20 * 60 * 1000,
+      config: MARKET_REGIME_CONFIG["15m"],
+      configVersion: "market-regime-2.0.0",
+      engineVersion: "0.1.0",
+      metadata: {
+        sourceTimeframe: "15m",
+        sourceCandleCount: 130
+      }
+    });
+    expect(response.metadata.sourceTimeframe).toBe("15m");
+    expect(response.metadata.sourceCandleCount).toBe(130);
+    expect(response.metadata.derivedTimeframe).toBeUndefined();
+    expect(response.metadata.aggregationVersion).toBeUndefined();
   });
 });

--- a/src/engine/marketRegime/__tests__/buildRegimeCurrent.test.ts
+++ b/src/engine/marketRegime/__tests__/buildRegimeCurrent.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { buildRegimeCurrent } from "../buildRegimeCurrent.js";
+import { aggregate15mTo1h } from "../../candles/aggregateCandles.js";
 import { MARKET_REGIME_CONFIG } from "../config.js";
 
 const FIFTEEN_MIN_MS = 15 * 60 * 1000;
@@ -74,7 +75,7 @@ describe("buildRegimeCurrent", () => {
     expect(response.marketReasons.map((r) => r.code)).toContain("DATA_HARD_STALE");
   });
 
-  it("merges caller-supplied source/derived metadata fields into the response", () => {
+  it("passes through caller-supplied metadata fields without interpreting them", () => {
     const lastCandleUnixMs = flatCandles[flatCandles.length - 1].unixMs;
     const response = buildRegimeCurrent({
       feed: { ...feed, timeframe: "1h" as const },
@@ -116,5 +117,35 @@ describe("buildRegimeCurrent", () => {
     expect(response.metadata.sourceCandleCount).toBe(130);
     expect(response.metadata.derivedTimeframe).toBeUndefined();
     expect(response.metadata.aggregationVersion).toBeUndefined();
+  });
+});
+
+describe("buildRegimeCurrent with aggregated 1h candles", () => {
+  it("classifies using aggregated 1h candles passed to 1h config", () => {
+    const { candles: aggregated } = aggregate15mTo1h(flatCandles);
+    expect(aggregated.length).toBeGreaterThan(0);
+
+    const lastCandleUnixMs = aggregated[aggregated.length - 1].unixMs;
+    const response = buildRegimeCurrent({
+      feed: { ...feed, timeframe: "1h" as const },
+      candles: aggregated,
+      nowUnixMs: lastCandleUnixMs + 20 * 60 * 1000,
+      config: MARKET_REGIME_CONFIG["1h"],
+      configVersion: "market-regime-2.0.0",
+      engineVersion: "0.1.0",
+      metadata: {
+        sourceTimeframe: "15m",
+        sourceCandleCount: flatCandles.length,
+        derivedTimeframe: "1h",
+        aggregationVersion: "ohlcv-agg-v1"
+      }
+    });
+    expect(response.timeframe).toBe("1h");
+    expect(response.metadata.sourceTimeframe).toBe("15m");
+    expect(response.metadata.sourceCandleCount).toBe(flatCandles.length);
+    expect(response.metadata.derivedTimeframe).toBe("1h");
+    expect(response.metadata.aggregationVersion).toBe("ohlcv-agg-v1");
+    expect(response.metadata.candleCount).toBe(aggregated.length);
+    expect(["UP", "DOWN", "CHOP"]).toContain(response.regime);
   });
 });

--- a/src/engine/marketRegime/__tests__/config.test.ts
+++ b/src/engine/marketRegime/__tests__/config.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { MARKET_REGIME_CONFIG } from "../config.js";
+import {
+  FIFTEEN_MIN_MS,
+  ONE_HOUR_MS,
+  FIFTEEN_MINUTES_PER_HOUR
+} from "../../candles/aggregateCandles.js";
 
 describe("MARKET_REGIME_CONFIG[15m]", () => {
   it("has timeframeMs equal to 15 minutes", () => {
@@ -44,5 +49,21 @@ describe("MARKET_REGIME_CONFIG[1h]", () => {
     expect(config.freshness.closedCandleDelayMs).toBe(5 * 60 * 1000);
     expect(config.freshness.softStaleMs).toBe(75 * 60 * 1000);
     expect(config.freshness.hardStaleMs).toBe(90 * 60 * 1000);
+  });
+});
+
+describe("aggregateCandles constants match config", () => {
+  it("FIFTEEN_MIN_MS matches config 15m timeframeMs", () => {
+    expect(FIFTEEN_MIN_MS).toBe(MARKET_REGIME_CONFIG["15m"].timeframeMs);
+  });
+
+  it("ONE_HOUR_MS matches config 1h timeframeMs", () => {
+    expect(ONE_HOUR_MS).toBe(MARKET_REGIME_CONFIG["1h"].timeframeMs);
+  });
+
+  it("FIFTEEN_MINUTES_PER_HOUR equals the ratio", () => {
+    expect(FIFTEEN_MINUTES_PER_HOUR).toBe(
+      MARKET_REGIME_CONFIG["1h"].timeframeMs / MARKET_REGIME_CONFIG["15m"].timeframeMs
+    );
   });
 });

--- a/src/engine/marketRegime/__tests__/config.test.ts
+++ b/src/engine/marketRegime/__tests__/config.test.ts
@@ -23,3 +23,26 @@ describe("MARKET_REGIME_CONFIG[15m]", () => {
     expect(config.freshness.hardStaleMs).toBe(35 * 60 * 1000);
   });
 });
+
+describe("MARKET_REGIME_CONFIG[1h]", () => {
+  it("has timeframeMs equal to 1 hour", () => {
+    expect(MARKET_REGIME_CONFIG["1h"].timeframeMs).toBe(60 * 60 * 1000);
+  });
+
+  it("has the original 1h indicator and regime windows", () => {
+    const config = MARKET_REGIME_CONFIG["1h"];
+    expect(config.indicators.volShortWindow).toBe(8);
+    expect(config.indicators.volLongWindow).toBe(21);
+    expect(config.indicators.trendWindow).toBe(14);
+    expect(config.indicators.compressionWindow).toBe(20);
+    expect(config.regime.confirmBars).toBe(1);
+    expect(config.suitability.minCandles).toBe(30);
+  });
+
+  it("has the original 1h freshness thresholds", () => {
+    const config = MARKET_REGIME_CONFIG["1h"];
+    expect(config.freshness.closedCandleDelayMs).toBe(5 * 60 * 1000);
+    expect(config.freshness.softStaleMs).toBe(75 * 60 * 1000);
+    expect(config.freshness.hardStaleMs).toBe(90 * 60 * 1000);
+  });
+});

--- a/src/engine/marketRegime/__tests__/regimeCandleReadPlan.test.ts
+++ b/src/engine/marketRegime/__tests__/regimeCandleReadPlan.test.ts
@@ -11,6 +11,10 @@ describe("buildRegimeCandleReadPlan(15m)", () => {
     nowUnixMs: NOW
   });
 
+  it("returns mode direct", () => {
+    expect(plan.mode).toBe("direct");
+  });
+
   it("uses 15m as the stored source timeframe", () => {
     expect(plan.sourceTimeframe).toBe("15m");
   });
@@ -22,18 +26,18 @@ describe("buildRegimeCandleReadPlan(15m)", () => {
     );
   });
 
-  it("does not produce a derived cutoff", () => {
-    expect(plan.derivedCutoffUnixMs).toBeUndefined();
-  });
-
   it("uses sourceLimit = max(volLongWindow, minCandles) + READ_BUFFER", () => {
     const cfg = MARKET_REGIME_CONFIG["15m"];
     const expected = Math.max(cfg.indicators.volLongWindow, cfg.suitability.minCandles) + 50;
     expect(plan.sourceLimit).toBe(expected);
   });
 
-  it("returns direct metadata hints", () => {
-    expect(plan.metadataHints).toEqual({ sourceTimeframe: "15m" });
+  it("returns direct sourceMetadata", () => {
+    expect(plan.sourceMetadata).toEqual({ sourceTimeframe: "15m" });
+  });
+
+  it("does not have derivedCutoffUnixMs on the direct plan", () => {
+    expect("derivedCutoffUnixMs" in plan).toBe(false);
   });
 });
 
@@ -41,6 +45,10 @@ describe("buildRegimeCandleReadPlan(1h)", () => {
   const plan = buildRegimeCandleReadPlan({
     requestedTimeframe: "1h",
     nowUnixMs: NOW
+  });
+
+  it("returns mode derived", () => {
+    expect(plan.mode).toBe("derived");
   });
 
   it("uses 15m as the stored source timeframe", () => {
@@ -55,6 +63,7 @@ describe("buildRegimeCandleReadPlan(1h)", () => {
   });
 
   it("computes derivedCutoffUnixMs from the 1h freshness config", () => {
+    if (plan.mode !== "derived") throw new Error("expected derived mode");
     const cfg = MARKET_REGIME_CONFIG["1h"];
     expect(plan.derivedCutoffUnixMs).toBe(
       closedCandleCutoffUnixMs(NOW, cfg.timeframeMs, cfg.freshness.closedCandleDelayMs)
@@ -69,11 +78,16 @@ describe("buildRegimeCandleReadPlan(1h)", () => {
     expect(plan.sourceLimit).toBe(expected);
   });
 
-  it("returns derived metadata hints", () => {
-    expect(plan.metadataHints).toEqual({
+  it("returns derived sourceMetadata", () => {
+    expect(plan.sourceMetadata).toEqual({
       sourceTimeframe: "15m",
       derivedTimeframe: "1h",
       aggregationVersion: "ohlcv-agg-v1"
     });
+  });
+
+  it("has derivedCutoffUnixMs as a required number (not optional)", () => {
+    if (plan.mode !== "derived") throw new Error("expected derived mode");
+    expect(typeof plan.derivedCutoffUnixMs).toBe("number");
   });
 });

--- a/src/engine/marketRegime/__tests__/regimeCandleReadPlan.test.ts
+++ b/src/engine/marketRegime/__tests__/regimeCandleReadPlan.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { MARKET_REGIME_CONFIG } from "../config.js";
+import { closedCandleCutoffUnixMs } from "../closedCandleCutoff.js";
+import { buildRegimeCandleReadPlan } from "../regimeCandleReadPlan.js";
+
+const NOW = 1_777_000_000_000;
+
+describe("buildRegimeCandleReadPlan(15m)", () => {
+  const plan = buildRegimeCandleReadPlan({
+    requestedTimeframe: "15m",
+    nowUnixMs: NOW
+  });
+
+  it("uses 15m as the stored source timeframe", () => {
+    expect(plan.sourceTimeframe).toBe("15m");
+  });
+
+  it("computes sourceCutoffUnixMs from the 15m freshness config", () => {
+    const cfg = MARKET_REGIME_CONFIG["15m"];
+    expect(plan.sourceCutoffUnixMs).toBe(
+      closedCandleCutoffUnixMs(NOW, cfg.timeframeMs, cfg.freshness.closedCandleDelayMs)
+    );
+  });
+
+  it("does not produce a derived cutoff", () => {
+    expect(plan.derivedCutoffUnixMs).toBeUndefined();
+  });
+
+  it("uses sourceLimit = max(volLongWindow, minCandles) + READ_BUFFER", () => {
+    const cfg = MARKET_REGIME_CONFIG["15m"];
+    const expected = Math.max(cfg.indicators.volLongWindow, cfg.suitability.minCandles) + 50;
+    expect(plan.sourceLimit).toBe(expected);
+  });
+
+  it("returns direct metadata hints", () => {
+    expect(plan.metadataHints).toEqual({ sourceTimeframe: "15m" });
+  });
+});
+
+describe("buildRegimeCandleReadPlan(1h)", () => {
+  const plan = buildRegimeCandleReadPlan({
+    requestedTimeframe: "1h",
+    nowUnixMs: NOW
+  });
+
+  it("uses 15m as the stored source timeframe", () => {
+    expect(plan.sourceTimeframe).toBe("15m");
+  });
+
+  it("computes sourceCutoffUnixMs from the 15m freshness config", () => {
+    const cfg = MARKET_REGIME_CONFIG["15m"];
+    expect(plan.sourceCutoffUnixMs).toBe(
+      closedCandleCutoffUnixMs(NOW, cfg.timeframeMs, cfg.freshness.closedCandleDelayMs)
+    );
+  });
+
+  it("computes derivedCutoffUnixMs from the 1h freshness config", () => {
+    const cfg = MARKET_REGIME_CONFIG["1h"];
+    expect(plan.derivedCutoffUnixMs).toBe(
+      closedCandleCutoffUnixMs(NOW, cfg.timeframeMs, cfg.freshness.closedCandleDelayMs)
+    );
+  });
+
+  it("uses sourceLimit = requiredDerivedBars * 4 + DERIVED_SOURCE_READ_BUFFER_15M", () => {
+    const cfg = MARKET_REGIME_CONFIG["1h"];
+    const requiredDerivedBars =
+      Math.max(cfg.indicators.volLongWindow, cfg.suitability.minCandles) + 50;
+    const expected = requiredDerivedBars * 4 + 32;
+    expect(plan.sourceLimit).toBe(expected);
+  });
+
+  it("returns derived metadata hints", () => {
+    expect(plan.metadataHints).toEqual({
+      sourceTimeframe: "15m",
+      derivedTimeframe: "1h",
+      aggregationVersion: "ohlcv-agg-v1"
+    });
+  });
+});

--- a/src/engine/marketRegime/buildRegimeCurrent.ts
+++ b/src/engine/marketRegime/buildRegimeCurrent.ts
@@ -11,6 +11,13 @@ import { computeFreshness } from "./freshness.js";
 import { evaluateMarketClmmSuitability } from "./evaluateMarketClmmSuitability.js";
 import type { MarketTimeframeConfig } from "./config.js";
 
+export interface BuildRegimeCurrentMetadata {
+  sourceTimeframe: "15m";
+  sourceCandleCount: number;
+  derivedTimeframe?: "1h";
+  aggregationVersion?: "ohlcv-agg-v1";
+}
+
 export interface BuildRegimeCurrentInput {
   feed: {
     symbol: string;
@@ -24,6 +31,7 @@ export interface BuildRegimeCurrentInput {
   config: MarketTimeframeConfig;
   configVersion: string;
   engineVersion: string;
+  metadata: BuildRegimeCurrentMetadata;
 }
 
 const buildMarketReasons = (
@@ -75,7 +83,7 @@ export const buildRegimeCurrent = (input: BuildRegimeCurrentInput): RegimeCurren
   if (input.candles.length === 0) {
     throw new Error("buildRegimeCurrent requires at least one candle");
   }
-  const { feed, candles, nowUnixMs, config, configVersion, engineVersion } = input;
+  const { feed, candles, nowUnixMs, config, configVersion, engineVersion, metadata } = input;
 
   const telemetry = computeIndicators(candles, config.indicators);
   const { regime, reasons: regimeReasons } = classifyMarketRegime(telemetry, config.regime);
@@ -116,7 +124,15 @@ export const buildRegimeCurrent = (input: BuildRegimeCurrentInput): RegimeCurren
     metadata: {
       engineVersion,
       configVersion,
-      candleCount: candles.length
+      candleCount: candles.length,
+      sourceTimeframe: metadata.sourceTimeframe,
+      sourceCandleCount: metadata.sourceCandleCount,
+      ...(metadata.derivedTimeframe !== undefined
+        ? { derivedTimeframe: metadata.derivedTimeframe }
+        : {}),
+      ...(metadata.aggregationVersion !== undefined
+        ? { aggregationVersion: metadata.aggregationVersion }
+        : {})
     }
   };
 };

--- a/src/engine/marketRegime/buildRegimeCurrent.ts
+++ b/src/engine/marketRegime/buildRegimeCurrent.ts
@@ -11,13 +11,6 @@ import { computeFreshness } from "./freshness.js";
 import { evaluateMarketClmmSuitability } from "./evaluateMarketClmmSuitability.js";
 import type { MarketTimeframeConfig } from "./config.js";
 
-export interface BuildRegimeCurrentMetadata {
-  sourceTimeframe: "15m";
-  sourceCandleCount: number;
-  derivedTimeframe?: "1h";
-  aggregationVersion?: "ohlcv-agg-v1";
-}
-
 export interface BuildRegimeCurrentInput {
   feed: {
     symbol: string;
@@ -31,7 +24,12 @@ export interface BuildRegimeCurrentInput {
   config: MarketTimeframeConfig;
   configVersion: string;
   engineVersion: string;
-  metadata: BuildRegimeCurrentMetadata;
+  metadata: {
+    sourceTimeframe: string;
+    sourceCandleCount: number;
+    derivedTimeframe?: string;
+    aggregationVersion?: string;
+  };
 }
 
 const buildMarketReasons = (

--- a/src/engine/marketRegime/config.ts
+++ b/src/engine/marketRegime/config.ts
@@ -1,7 +1,9 @@
+import type { RegimeReadTimeframe } from "../../contract/v1/types.js";
+
 export const MARKET_REGIME_CONFIG_VERSION = "market-regime-2.0.0" as const;
 
 export interface MarketTimeframeConfig {
-  timeframe: "15m";
+  timeframe: RegimeReadTimeframe;
   timeframeMs: number;
   indicators: {
     volShortWindow: number;
@@ -32,8 +34,9 @@ export interface MarketTimeframeConfig {
 }
 
 const FIFTEEN_MIN_MS = 15 * 60 * 1000;
+const ONE_HOUR_MS = 60 * 60 * 1000;
 
-export const MARKET_REGIME_CONFIG: Record<"15m", MarketTimeframeConfig> = {
+export const MARKET_REGIME_CONFIG: Record<RegimeReadTimeframe, MarketTimeframeConfig> = {
   "15m": {
     timeframe: "15m",
     timeframeMs: FIFTEEN_MIN_MS,
@@ -62,6 +65,36 @@ export const MARKET_REGIME_CONFIG: Record<"15m", MarketTimeframeConfig> = {
       closedCandleDelayMs: 2 * 60 * 1000,
       softStaleMs: 25 * 60 * 1000,
       hardStaleMs: 35 * 60 * 1000
+    }
+  },
+  "1h": {
+    timeframe: "1h",
+    timeframeMs: ONE_HOUR_MS,
+    indicators: {
+      volShortWindow: 8,
+      volLongWindow: 21,
+      trendWindow: 14,
+      compressionWindow: 20
+    },
+    regime: {
+      confirmBars: 1,
+      minHoldBars: 0,
+      enterUpTrend: 0.6,
+      exitUpTrend: 0.35,
+      enterDownTrend: -0.6,
+      exitDownTrend: -0.35,
+      chopVolRatioMax: 1.4
+    },
+    suitability: {
+      allowedVolRatioMax: 1.3,
+      extremeVolRatio: 1.6,
+      extremeCompression: 0.18,
+      minCandles: 30
+    },
+    freshness: {
+      closedCandleDelayMs: 5 * 60 * 1000,
+      softStaleMs: 75 * 60 * 1000,
+      hardStaleMs: 90 * 60 * 1000
     }
   }
 };

--- a/src/engine/marketRegime/regimeCandleReadPlan.ts
+++ b/src/engine/marketRegime/regimeCandleReadPlan.ts
@@ -6,23 +6,32 @@ const READ_BUFFER = 50;
 const FIFTEEN_MINUTES_PER_HOUR = 4;
 const DERIVED_SOURCE_READ_BUFFER_15M = 32;
 
-export interface DirectMetadataHints {
+export interface DirectSourceMetadata {
   sourceTimeframe: "15m";
 }
 
-export interface DerivedMetadataHints {
+export interface DerivedSourceMetadata {
   sourceTimeframe: "15m";
   derivedTimeframe: "1h";
   aggregationVersion: "ohlcv-agg-v1";
 }
 
-export interface RegimeCandleReadPlan {
-  sourceTimeframe: "15m";
-  sourceCutoffUnixMs: number;
-  sourceLimit: number;
-  derivedCutoffUnixMs?: number;
-  metadataHints: DirectMetadataHints | DerivedMetadataHints;
-}
+export type RegimeCandleReadPlan =
+  | {
+      mode: "direct";
+      sourceTimeframe: "15m";
+      sourceCutoffUnixMs: number;
+      sourceLimit: number;
+      sourceMetadata: DirectSourceMetadata;
+    }
+  | {
+      mode: "derived";
+      sourceTimeframe: "15m";
+      sourceCutoffUnixMs: number;
+      sourceLimit: number;
+      derivedCutoffUnixMs: number;
+      sourceMetadata: DerivedSourceMetadata;
+    };
 
 export interface BuildRegimeCandleReadPlanInput {
   requestedTimeframe: RegimeReadTimeframe;
@@ -40,16 +49,16 @@ export const buildRegimeCandleReadPlan = (
   );
 
   if (input.requestedTimeframe === "15m") {
-    const requestedConfig = MARKET_REGIME_CONFIG["15m"];
     const sourceLimit =
-      Math.max(requestedConfig.indicators.volLongWindow, requestedConfig.suitability.minCandles) +
+      Math.max(sourceConfig.indicators.volLongWindow, sourceConfig.suitability.minCandles) +
       READ_BUFFER;
 
     return {
+      mode: "direct",
       sourceTimeframe: "15m",
       sourceCutoffUnixMs,
       sourceLimit,
-      metadataHints: { sourceTimeframe: "15m" }
+      sourceMetadata: { sourceTimeframe: "15m" }
     };
   }
 
@@ -66,11 +75,12 @@ export const buildRegimeCandleReadPlan = (
     requiredDerivedBars * FIFTEEN_MINUTES_PER_HOUR + DERIVED_SOURCE_READ_BUFFER_15M;
 
   return {
+    mode: "derived",
     sourceTimeframe: "15m",
     sourceCutoffUnixMs,
     sourceLimit,
     derivedCutoffUnixMs,
-    metadataHints: {
+    sourceMetadata: {
       sourceTimeframe: "15m",
       derivedTimeframe: "1h",
       aggregationVersion: "ohlcv-agg-v1"

--- a/src/engine/marketRegime/regimeCandleReadPlan.ts
+++ b/src/engine/marketRegime/regimeCandleReadPlan.ts
@@ -1,0 +1,79 @@
+import type { RegimeReadTimeframe } from "../../contract/v1/types.js";
+import { MARKET_REGIME_CONFIG } from "./config.js";
+import { closedCandleCutoffUnixMs } from "./closedCandleCutoff.js";
+
+const READ_BUFFER = 50;
+const FIFTEEN_MINUTES_PER_HOUR = 4;
+const DERIVED_SOURCE_READ_BUFFER_15M = 32;
+
+export interface DirectMetadataHints {
+  sourceTimeframe: "15m";
+}
+
+export interface DerivedMetadataHints {
+  sourceTimeframe: "15m";
+  derivedTimeframe: "1h";
+  aggregationVersion: "ohlcv-agg-v1";
+}
+
+export interface RegimeCandleReadPlan {
+  sourceTimeframe: "15m";
+  sourceCutoffUnixMs: number;
+  sourceLimit: number;
+  derivedCutoffUnixMs?: number;
+  metadataHints: DirectMetadataHints | DerivedMetadataHints;
+}
+
+export interface BuildRegimeCandleReadPlanInput {
+  requestedTimeframe: RegimeReadTimeframe;
+  nowUnixMs: number;
+}
+
+export const buildRegimeCandleReadPlan = (
+  input: BuildRegimeCandleReadPlanInput
+): RegimeCandleReadPlan => {
+  const sourceConfig = MARKET_REGIME_CONFIG["15m"];
+  const sourceCutoffUnixMs = closedCandleCutoffUnixMs(
+    input.nowUnixMs,
+    sourceConfig.timeframeMs,
+    sourceConfig.freshness.closedCandleDelayMs
+  );
+
+  if (input.requestedTimeframe === "15m") {
+    const requestedConfig = MARKET_REGIME_CONFIG["15m"];
+    const sourceLimit =
+      Math.max(requestedConfig.indicators.volLongWindow, requestedConfig.suitability.minCandles) +
+      READ_BUFFER;
+
+    return {
+      sourceTimeframe: "15m",
+      sourceCutoffUnixMs,
+      sourceLimit,
+      metadataHints: { sourceTimeframe: "15m" }
+    };
+  }
+
+  const derivedConfig = MARKET_REGIME_CONFIG["1h"];
+  const derivedCutoffUnixMs = closedCandleCutoffUnixMs(
+    input.nowUnixMs,
+    derivedConfig.timeframeMs,
+    derivedConfig.freshness.closedCandleDelayMs
+  );
+  const requiredDerivedBars =
+    Math.max(derivedConfig.indicators.volLongWindow, derivedConfig.suitability.minCandles) +
+    READ_BUFFER;
+  const sourceLimit =
+    requiredDerivedBars * FIFTEEN_MINUTES_PER_HOUR + DERIVED_SOURCE_READ_BUFFER_15M;
+
+  return {
+    sourceTimeframe: "15m",
+    sourceCutoffUnixMs,
+    sourceLimit,
+    derivedCutoffUnixMs,
+    metadataHints: {
+      sourceTimeframe: "15m",
+      derivedTimeframe: "1h",
+      aggregationVersion: "ohlcv-agg-v1"
+    }
+  };
+};

--- a/src/http/__tests__/regimeCurrent.e2e.test.ts
+++ b/src/http/__tests__/regimeCurrent.e2e.test.ts
@@ -52,6 +52,9 @@ afterEach(() => {
 const queryString =
   "?symbol=SOL%2FUSDC&source=birdeye&network=solana-mainnet&poolAddress=Pool111&timeframe=15m";
 
+const queryString1h =
+  "?symbol=SOL%2FUSDC&source=birdeye&network=solana-mainnet&poolAddress=Pool111&timeframe=1h";
+
 describe("GET /v1/regime/current", () => {
   it("returns 400 when a required selector is missing", async () => {
     process.env.LEDGER_DB_PATH = tempDb();
@@ -106,6 +109,10 @@ describe("GET /v1/regime/current", () => {
     expect(body.metadata.candleCount).toBeGreaterThanOrEqual(
       MARKET_REGIME_CONFIG["15m"].suitability.minCandles
     );
+    expect(body.metadata.sourceTimeframe).toBe("15m");
+    expect(body.metadata.sourceCandleCount).toBe(body.metadata.candleCount);
+    expect(body.metadata.derivedTimeframe).toBeUndefined();
+    expect(body.metadata.aggregationVersion).toBeUndefined();
     expect(["ALLOWED", "CAUTION", "BLOCKED", "UNKNOWN"]).toContain(body.clmmSuitability.status);
     expect(Array.isArray(body.clmmSuitability.reasons)).toBe(true);
     expect(Array.isArray(body.marketReasons)).toBe(true);
@@ -142,5 +149,169 @@ describe("GET /v1/regime/current", () => {
     expect(afterCounts.plans).toBe(baseCounts.plans);
     expect(afterCounts.planRequests).toBe(baseCounts.planRequests);
     expect(afterCounts.executionResults).toBe(baseCounts.executionResults);
+  });
+
+  it("returns 200 with derived 1h regime classified from stored 15m candles", async () => {
+    process.env.LEDGER_DB_PATH = tempDb();
+    process.env.CANDLES_INGEST_TOKEN = "test-token";
+    const app = buildApp();
+
+    const recordedIso = new Date().toISOString();
+    await app.inject({
+      method: "POST",
+      url: "/v1/candles",
+      headers: { "X-Candles-Ingest-Token": "test-token" },
+      payload: ingestPayload(200, recordedIso)
+    });
+
+    const res = await app.inject({ method: "GET", url: `/v1/regime/current${queryString1h}` });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.schemaVersion).toBe("1.0");
+    expect(body.timeframe).toBe("1h");
+    expect(["UP", "DOWN", "CHOP"]).toContain(body.regime);
+    expect(body.metadata.sourceTimeframe).toBe("15m");
+    expect(body.metadata.sourceCandleCount).toBeGreaterThanOrEqual(body.metadata.candleCount * 4);
+    expect(body.metadata.derivedTimeframe).toBe("1h");
+    expect(body.metadata.aggregationVersion).toBe("ohlcv-agg-v1");
+    expect(body.metadata.candleCount).toBeGreaterThan(0);
+    expect(Array.isArray(body.marketReasons)).toBe(true);
+  });
+
+  it("derived 1h does not classify the incomplete current-hour aggregate", async () => {
+    process.env.LEDGER_DB_PATH = tempDb();
+    process.env.CANDLES_INGEST_TOKEN = "test-token";
+    const app = buildApp();
+
+    await app.inject({
+      method: "POST",
+      url: "/v1/candles",
+      headers: { "X-Candles-Ingest-Token": "test-token" },
+      payload: ingestPayload(200, new Date().toISOString())
+    });
+
+    const res = await app.inject({ method: "GET", url: `/v1/regime/current${queryString1h}` });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+
+    expect(body.freshness.lastCandleUnixMs).toBeLessThan(Date.now());
+
+    const ONE_HOUR_MS = 60 * 60 * 1000;
+    expect(body.freshness.lastCandleUnixMs % ONE_HOUR_MS).toBe(0);
+  });
+
+  it("returns 404 CANDLES_NOT_FOUND when no derived 1h bars survive the cutoff", async () => {
+    process.env.LEDGER_DB_PATH = tempDb();
+    process.env.CANDLES_INGEST_TOKEN = "test-token";
+    const app = buildApp();
+
+    const ONE_HOUR_MS = 60 * 60 * 1000;
+    const sourceConfig = MARKET_REGIME_CONFIG["15m"];
+
+    const sourceCutoffUnixMs =
+      Math.floor((Date.now() - sourceConfig.freshness.closedCandleDelayMs) / FIFTEEN_MIN_MS) *
+        FIFTEEN_MIN_MS -
+      FIFTEEN_MIN_MS;
+    const hourOpen =
+      Math.floor((sourceCutoffUnixMs - 4 * FIFTEEN_MIN_MS) / ONE_HOUR_MS) * ONE_HOUR_MS;
+    const partialCandles = [0, 1, 2].map((i) => ({
+      unixMs: hourOpen + i * FIFTEEN_MIN_MS,
+      open: 100,
+      high: 100.5,
+      low: 99.5,
+      close: 100,
+      volume: 1
+    }));
+
+    await app.inject({
+      method: "POST",
+      url: "/v1/candles",
+      headers: { "X-Candles-Ingest-Token": "test-token" },
+      payload: {
+        schemaVersion: "1.0",
+        source: "birdeye",
+        network: "solana-mainnet",
+        poolAddress: "Pool111",
+        symbol: "SOL/USDC",
+        timeframe: "15m",
+        sourceRecordedAtIso: new Date().toISOString(),
+        candles: partialCandles
+      }
+    });
+
+    const res = await app.inject({ method: "GET", url: `/v1/regime/current${queryString1h}` });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error.code).toBe("CANDLES_NOT_FOUND");
+  });
+
+  it("derived 1h with non-zero but insufficient derived bars returns DATA_INSUFFICIENT_SAMPLES", async () => {
+    process.env.LEDGER_DB_PATH = tempDb();
+    process.env.CANDLES_INGEST_TOKEN = "test-token";
+    const app = buildApp();
+
+    const ONE_HOUR_MS = 60 * 60 * 1000;
+    const sourceConfig = MARKET_REGIME_CONFIG["15m"];
+
+    const sourceCutoffUnixMs =
+      Math.floor((Date.now() - sourceConfig.freshness.closedCandleDelayMs) / FIFTEEN_MIN_MS) *
+        FIFTEEN_MIN_MS -
+      FIFTEEN_MIN_MS;
+    const lastHourOpen = Math.floor(sourceCutoffUnixMs / ONE_HOUR_MS) * ONE_HOUR_MS - ONE_HOUR_MS;
+    const startHourOpen = lastHourOpen - 4 * ONE_HOUR_MS;
+    const candles: Array<{
+      unixMs: number;
+      open: number;
+      high: number;
+      low: number;
+      close: number;
+      volume: number;
+    }> = [];
+    for (let h = 0; h < 5; h += 1) {
+      for (let q = 0; q < 4; q += 1) {
+        candles.push({
+          unixMs: startHourOpen + h * ONE_HOUR_MS + q * FIFTEEN_MIN_MS,
+          open: 100,
+          high: 100.5,
+          low: 99.5,
+          close: 100,
+          volume: 1
+        });
+      }
+    }
+
+    await app.inject({
+      method: "POST",
+      url: "/v1/candles",
+      headers: { "X-Candles-Ingest-Token": "test-token" },
+      payload: {
+        schemaVersion: "1.0",
+        source: "birdeye",
+        network: "solana-mainnet",
+        poolAddress: "Pool111",
+        symbol: "SOL/USDC",
+        timeframe: "15m",
+        sourceRecordedAtIso: new Date().toISOString(),
+        candles
+      }
+    });
+
+    const res = await app.inject({ method: "GET", url: `/v1/regime/current${queryString1h}` });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.metadata.candleCount).toBeLessThan(
+      MARKET_REGIME_CONFIG["1h"].suitability.minCandles
+    );
+    expect(body.marketReasons.map((r: { code: string }) => r.code)).toContain(
+      "DATA_INSUFFICIENT_SAMPLES"
+    );
+    expect(body.clmmSuitability.status).toBe("UNKNOWN");
+  });
+
+  it("returns 404 CANDLES_NOT_FOUND for derived 1h when no 15m source candles exist at all", async () => {
+    process.env.LEDGER_DB_PATH = tempDb();
+    const app = buildApp();
+    const res = await app.inject({ method: "GET", url: `/v1/regime/current${queryString1h}` });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error.code).toBe("CANDLES_NOT_FOUND");
   });
 });

--- a/src/http/__tests__/regimeCurrent.e2e.test.ts
+++ b/src/http/__tests__/regimeCurrent.e2e.test.ts
@@ -7,7 +7,15 @@ import { createLedgerStore, getLedgerCounts } from "../../ledger/store.js";
 import { MARKET_REGIME_CONFIG } from "../../engine/marketRegime/config.js";
 
 const FIFTEEN_MIN_MS = 15 * 60 * 1000;
+const ONE_HOUR_MS = 60 * 60 * 1000;
 const createdDbPaths: string[] = [];
+
+const computeSourceCutoffUnixMs = () =>
+  Math.floor(
+    (Date.now() - MARKET_REGIME_CONFIG["15m"].freshness.closedCandleDelayMs) / FIFTEEN_MIN_MS
+  ) *
+    FIFTEEN_MIN_MS -
+  FIFTEEN_MIN_MS;
 
 const tempDb = (): string => {
   const path = join(
@@ -196,7 +204,6 @@ describe("GET /v1/regime/current", () => {
 
     expect(body.freshness.lastCandleUnixMs).toBeLessThan(Date.now());
 
-    const ONE_HOUR_MS = 60 * 60 * 1000;
     expect(body.freshness.lastCandleUnixMs % ONE_HOUR_MS).toBe(0);
   });
 
@@ -205,13 +212,7 @@ describe("GET /v1/regime/current", () => {
     process.env.CANDLES_INGEST_TOKEN = "test-token";
     const app = buildApp();
 
-    const ONE_HOUR_MS = 60 * 60 * 1000;
-    const sourceConfig = MARKET_REGIME_CONFIG["15m"];
-
-    const sourceCutoffUnixMs =
-      Math.floor((Date.now() - sourceConfig.freshness.closedCandleDelayMs) / FIFTEEN_MIN_MS) *
-        FIFTEEN_MIN_MS -
-      FIFTEEN_MIN_MS;
+    const sourceCutoffUnixMs = computeSourceCutoffUnixMs();
     const hourOpen =
       Math.floor((sourceCutoffUnixMs - 4 * FIFTEEN_MIN_MS) / ONE_HOUR_MS) * ONE_HOUR_MS;
     const partialCandles = [0, 1, 2].map((i) => ({
@@ -249,13 +250,7 @@ describe("GET /v1/regime/current", () => {
     process.env.CANDLES_INGEST_TOKEN = "test-token";
     const app = buildApp();
 
-    const ONE_HOUR_MS = 60 * 60 * 1000;
-    const sourceConfig = MARKET_REGIME_CONFIG["15m"];
-
-    const sourceCutoffUnixMs =
-      Math.floor((Date.now() - sourceConfig.freshness.closedCandleDelayMs) / FIFTEEN_MIN_MS) *
-        FIFTEEN_MIN_MS -
-      FIFTEEN_MIN_MS;
+    const sourceCutoffUnixMs = computeSourceCutoffUnixMs();
     const lastHourOpen = Math.floor(sourceCutoffUnixMs / ONE_HOUR_MS) * ONE_HOUR_MS - ONE_HOUR_MS;
     const startHourOpen = lastHourOpen - 4 * ONE_HOUR_MS;
     const candles: Array<{

--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -23,7 +23,9 @@ export const ERROR_DETAIL_CODES = {
   INVALID_TYPE: "INVALID_TYPE",
   INVALID_VALUE: "INVALID_VALUE",
   OUT_OF_RANGE: "OUT_OF_RANGE",
-  UNKNOWN_KEY: "UNKNOWN_KEY"
+  UNKNOWN_KEY: "UNKNOWN_KEY",
+  NO_SOURCE_CANDLES: "NO_SOURCE_CANDLES",
+  NO_DERIVED_CANDLES_AFTER_AGGREGATION: "NO_DERIVED_CANDLES_AFTER_AGGREGATION"
 } as const;
 
 export type ErrorDetailCode = (typeof ERROR_DETAIL_CODES)[keyof typeof ERROR_DETAIL_CODES];
@@ -209,9 +211,12 @@ export const duplicateCandleInBatchError = (
   });
 };
 
-export const candlesNotFoundError = (message: string): ContractValidationError => {
+export const candlesNotFoundError = (
+  message: string,
+  details: ErrorDetail[] = []
+): ContractValidationError => {
   return new ContractValidationError(404, {
     schemaVersion: SCHEMA_VERSION,
-    error: { code: ERROR_CODES.CANDLES_NOT_FOUND, message, details: [] }
+    error: { code: ERROR_CODES.CANDLES_NOT_FOUND, message, details }
   });
 };

--- a/src/http/handlers/regimeCurrent.ts
+++ b/src/http/handlers/regimeCurrent.ts
@@ -70,7 +70,11 @@ export const createRegimeCurrentHandler = (store: LedgerStore, candleStore?: Can
         nowUnixMs,
         config,
         configVersion: MARKET_REGIME_CONFIG_VERSION,
-        engineVersion: process.env.npm_package_version ?? "0.0.0"
+        engineVersion: process.env.npm_package_version ?? "0.0.0",
+        metadata: {
+          sourceTimeframe: query.timeframe as "15m",
+          sourceCandleCount: candles.length
+        }
       });
 
       return reply.code(200).send(response);

--- a/src/http/handlers/regimeCurrent.ts
+++ b/src/http/handlers/regimeCurrent.ts
@@ -31,7 +31,6 @@ export const createRegimeCurrentHandler = (store: LedgerStore, candleStore?: Can
             network: query.network,
             poolAddress: query.poolAddress,
             timeframe: plan.sourceTimeframe,
-            timeframeMs: MARKET_REGIME_CONFIG[plan.sourceTimeframe].timeframeMs,
             closedCandleCutoffUnixMs: plan.sourceCutoffUnixMs,
             limit: plan.sourceLimit
           })
@@ -41,7 +40,6 @@ export const createRegimeCurrentHandler = (store: LedgerStore, candleStore?: Can
             network: query.network,
             poolAddress: query.poolAddress,
             timeframe: plan.sourceTimeframe,
-            timeframeMs: MARKET_REGIME_CONFIG[plan.sourceTimeframe].timeframeMs,
             closedCandleCutoffUnixMs: plan.sourceCutoffUnixMs,
             limit: plan.sourceLimit
           });

--- a/src/http/handlers/regimeCurrent.ts
+++ b/src/http/handlers/regimeCurrent.ts
@@ -10,7 +10,7 @@ import {
 } from "../../engine/marketRegime/config.js";
 import { buildRegimeCurrent } from "../../engine/marketRegime/buildRegimeCurrent.js";
 import { buildRegimeCandleReadPlan } from "../../engine/marketRegime/regimeCandleReadPlan.js";
-import { aggregateCandles } from "../../engine/candles/aggregateCandles.js";
+import { aggregate15mTo1h } from "../../engine/candles/aggregateCandles.js";
 
 export const createRegimeCurrentHandler = (store: LedgerStore, candleStore?: CandleStore) => {
   return async (request: FastifyRequest, reply: FastifyReply) => {
@@ -31,40 +31,58 @@ export const createRegimeCurrentHandler = (store: LedgerStore, candleStore?: Can
             network: query.network,
             poolAddress: query.poolAddress,
             timeframe: plan.sourceTimeframe,
+            timeframeMs: MARKET_REGIME_CONFIG[plan.sourceTimeframe].timeframeMs,
             closedCandleCutoffUnixMs: plan.sourceCutoffUnixMs,
             limit: plan.sourceLimit
           })
-        : await Promise.resolve(
-            getLatestCandlesForFeed(store, {
-              symbol: query.symbol,
-              source: query.source,
-              network: query.network,
-              poolAddress: query.poolAddress,
-              timeframe: plan.sourceTimeframe,
-              closedCandleCutoffUnixMs: plan.sourceCutoffUnixMs,
-              limit: plan.sourceLimit
-            })
-          );
+        : getLatestCandlesForFeed(store, {
+            symbol: query.symbol,
+            source: query.source,
+            network: query.network,
+            poolAddress: query.poolAddress,
+            timeframe: plan.sourceTimeframe,
+            timeframeMs: MARKET_REGIME_CONFIG[plan.sourceTimeframe].timeframeMs,
+            closedCandleCutoffUnixMs: plan.sourceCutoffUnixMs,
+            limit: plan.sourceLimit
+          });
 
       if (sourceCandles.length === 0) {
         throw candlesNotFoundError(
           `No closed candles found for symbol="${query.symbol}", source="${query.source}", ` +
             `network="${query.network}", poolAddress="${query.poolAddress}", ` +
-            `sourceTimeframe="${plan.sourceTimeframe}", requestedTimeframe="${query.timeframe}".`
+            `sourceTimeframe="${plan.sourceTimeframe}", requestedTimeframe="${query.timeframe}".`,
+          [
+            {
+              code: "NO_SOURCE_CANDLES",
+              path: "$.sourceTimeframe",
+              message: "No source candles found before the freshness cutoff"
+            }
+          ]
         );
       }
 
-      let classifiedCandles = sourceCandles;
-      if (query.timeframe === "1h") {
-        const aggregated = aggregateCandles(sourceCandles, "1h");
-        classifiedCandles = aggregated.filter(
-          (candle) => candle.unixMs <= (plan.derivedCutoffUnixMs as number)
+      let candlesToClassify = sourceCandles;
+
+      if (plan.mode === "derived") {
+        const { candles: aggregated, telemetry } = aggregate15mTo1h(sourceCandles);
+        candlesToClassify = aggregated.filter(
+          (candle) => candle.unixMs <= plan.derivedCutoffUnixMs
         );
-        if (classifiedCandles.length === 0) {
+        if (candlesToClassify.length === 0) {
           throw candlesNotFoundError(
             `No complete derived 1h candles available before the 1h freshness cutoff for ` +
               `symbol="${query.symbol}", source="${query.source}", network="${query.network}", ` +
-              `poolAddress="${query.poolAddress}".`
+              `poolAddress="${query.poolAddress}".`,
+            [
+              {
+                code: "NO_DERIVED_CANDLES_AFTER_AGGREGATION",
+                path: "$.derivedTimeframe",
+                message:
+                  `Aggregation produced ${telemetry.completeBuckets} complete 1h buckets but none before the cutoff. ` +
+                  `Skipped: ${telemetry.skippedIncomplete} incomplete, ${telemetry.skippedGapInBucket} gaps, ` +
+                  `${telemetry.skippedMisaligned} misaligned, ${telemetry.skippedNonInteger} non-integer`
+              }
+            ]
           );
         }
       }
@@ -77,13 +95,13 @@ export const createRegimeCurrentHandler = (store: LedgerStore, candleStore?: Can
           poolAddress: query.poolAddress,
           timeframe: query.timeframe
         },
-        candles: classifiedCandles,
+        candles: candlesToClassify,
         nowUnixMs,
         config,
         configVersion: MARKET_REGIME_CONFIG_VERSION,
         engineVersion: process.env.npm_package_version ?? "0.0.0",
         metadata: {
-          ...plan.metadataHints,
+          ...plan.sourceMetadata,
           sourceCandleCount: sourceCandles.length
         }
       });

--- a/src/http/handlers/regimeCurrent.ts
+++ b/src/http/handlers/regimeCurrent.ts
@@ -8,10 +8,9 @@ import {
   MARKET_REGIME_CONFIG,
   MARKET_REGIME_CONFIG_VERSION
 } from "../../engine/marketRegime/config.js";
-import { closedCandleCutoffUnixMs } from "../../engine/marketRegime/closedCandleCutoff.js";
 import { buildRegimeCurrent } from "../../engine/marketRegime/buildRegimeCurrent.js";
-
-const READ_BUFFER = 50;
+import { buildRegimeCandleReadPlan } from "../../engine/marketRegime/regimeCandleReadPlan.js";
+import { aggregateCandles } from "../../engine/candles/aggregateCandles.js";
 
 export const createRegimeCurrentHandler = (store: LedgerStore, candleStore?: CandleStore) => {
   return async (request: FastifyRequest, reply: FastifyReply) => {
@@ -20,23 +19,20 @@ export const createRegimeCurrentHandler = (store: LedgerStore, candleStore?: Can
       const config = MARKET_REGIME_CONFIG[query.timeframe];
 
       const nowUnixMs = Date.now();
-      const cutoff = closedCandleCutoffUnixMs(
-        nowUnixMs,
-        config.timeframeMs,
-        config.freshness.closedCandleDelayMs
-      );
-      const limit =
-        Math.max(config.indicators.volLongWindow, config.suitability.minCandles) + READ_BUFFER;
+      const plan = buildRegimeCandleReadPlan({
+        requestedTimeframe: query.timeframe,
+        nowUnixMs
+      });
 
-      const candles = candleStore
+      const sourceCandles = candleStore
         ? await candleStore.getLatestCandlesForFeed({
             symbol: query.symbol,
             source: query.source,
             network: query.network,
             poolAddress: query.poolAddress,
-            timeframe: query.timeframe,
-            closedCandleCutoffUnixMs: cutoff,
-            limit
+            timeframe: plan.sourceTimeframe,
+            closedCandleCutoffUnixMs: plan.sourceCutoffUnixMs,
+            limit: plan.sourceLimit
           })
         : await Promise.resolve(
             getLatestCandlesForFeed(store, {
@@ -44,18 +40,33 @@ export const createRegimeCurrentHandler = (store: LedgerStore, candleStore?: Can
               source: query.source,
               network: query.network,
               poolAddress: query.poolAddress,
-              timeframe: query.timeframe,
-              closedCandleCutoffUnixMs: cutoff,
-              limit
+              timeframe: plan.sourceTimeframe,
+              closedCandleCutoffUnixMs: plan.sourceCutoffUnixMs,
+              limit: plan.sourceLimit
             })
           );
 
-      if (candles.length === 0) {
+      if (sourceCandles.length === 0) {
         throw candlesNotFoundError(
           `No closed candles found for symbol="${query.symbol}", source="${query.source}", ` +
             `network="${query.network}", poolAddress="${query.poolAddress}", ` +
-            `timeframe="${query.timeframe}".`
+            `sourceTimeframe="${plan.sourceTimeframe}", requestedTimeframe="${query.timeframe}".`
         );
+      }
+
+      let classifiedCandles = sourceCandles;
+      if (query.timeframe === "1h") {
+        const aggregated = aggregateCandles(sourceCandles, "1h");
+        classifiedCandles = aggregated.filter(
+          (candle) => candle.unixMs <= (plan.derivedCutoffUnixMs as number)
+        );
+        if (classifiedCandles.length === 0) {
+          throw candlesNotFoundError(
+            `No complete derived 1h candles available before the 1h freshness cutoff for ` +
+              `symbol="${query.symbol}", source="${query.source}", network="${query.network}", ` +
+              `poolAddress="${query.poolAddress}".`
+          );
+        }
       }
 
       const response = buildRegimeCurrent({
@@ -66,14 +77,14 @@ export const createRegimeCurrentHandler = (store: LedgerStore, candleStore?: Can
           poolAddress: query.poolAddress,
           timeframe: query.timeframe
         },
-        candles,
+        candles: classifiedCandles,
         nowUnixMs,
         config,
         configVersion: MARKET_REGIME_CONFIG_VERSION,
         engineVersion: process.env.npm_package_version ?? "0.0.0",
         metadata: {
-          sourceTimeframe: query.timeframe as "15m",
-          sourceCandleCount: candles.length
+          ...plan.metadataHints,
+          sourceCandleCount: sourceCandles.length
         }
       });
 

--- a/src/http/openapi.ts
+++ b/src/http/openapi.ts
@@ -170,7 +170,7 @@ export const buildOpenApiDocument = () => {
       "/v1/candles": {
         post: {
           summary:
-            "Ingest candle revisions for a logical feed (timeframe must be 15m; 1h removed in #41 until #42 derives 1h from 15m)",
+            "Ingest candle revisions for a logical feed. Provider ingestion is restricted to timeframe=15m; 1h regime reads are derived from stored 15m candles by GET /v1/regime/current.",
           responses: {
             "200": {
               description: "Per-slot insert/revise/idempotent/reject counts"
@@ -191,7 +191,7 @@ export const buildOpenApiDocument = () => {
       "/v1/regime/current": {
         get: {
           summary:
-            "Market-only regime classification + CLMM suitability for a 15m feed (timeframe must be 15m; 1h removed, see #41/#42)",
+            "Market-only regime classification + CLMM suitability. timeframe=15m classifies stored 15m candles directly; timeframe=1h derives complete 1h candles from stored 15m candles on the fly.",
           parameters: [
             {
               name: "symbol",
@@ -221,7 +221,7 @@ export const buildOpenApiDocument = () => {
               name: "timeframe",
               in: "query",
               required: true,
-              schema: { type: "string", enum: ["15m"] }
+              schema: { type: "string", enum: ["15m", "1h"] }
             }
           ],
           responses: {

--- a/src/http/openapi.ts
+++ b/src/http/openapi.ts
@@ -227,13 +227,18 @@ export const buildOpenApiDocument = () => {
           responses: {
             "200": {
               description:
-                "RegimeCurrentResponse with regime, telemetry, suitability, freshness, metadata"
+                "RegimeCurrentResponse with regime, telemetry, suitability, freshness, metadata. " +
+                'Metadata includes sourceTimeframe (always "15m"), sourceCandleCount, ' +
+                'and optionally derivedTimeframe ("1h") and aggregationVersion ("ohlcv-agg-v1") ' +
+                "when timeframe=1h aggregation was applied."
             },
             "400": {
               description: "VALIDATION_ERROR for missing/invalid selectors"
             },
             "404": {
-              description: "CANDLES_NOT_FOUND when no closed candles exist for the feed"
+              description:
+                "CANDLES_NOT_FOUND with detail code NO_SOURCE_CANDLES or " +
+                "NO_DERIVED_CANDLES_AFTER_AGGREGATION when no complete derived bars survive cutoff"
             }
           }
         }

--- a/src/ledger/__tests__/candleStore.test.ts
+++ b/src/ledger/__tests__/candleStore.test.ts
@@ -96,7 +96,7 @@ describe.skipIf(!process.env.DATABASE_URL)("CandleStore (PG)", () => {
       network: "solana-mainnet",
       poolAddress: "Pool111",
       timeframe: "15m",
-      timeframeMs: FIFTEEN_MIN_MS,
+
       closedCandleCutoffUnixMs: 10 * FIFTEEN_MIN_MS,
       limit: 100
     });
@@ -167,7 +167,7 @@ describe.skipIf(!process.env.DATABASE_URL)("CandleStore (PG)", () => {
       network: "solana-mainnet",
       poolAddress: "Pool111",
       timeframe: "15m",
-      timeframeMs: FIFTEEN_MIN_MS,
+
       closedCandleCutoffUnixMs: 10 * FIFTEEN_MIN_MS,
       limit: 100
     });
@@ -192,7 +192,7 @@ describe.skipIf(!process.env.DATABASE_URL)("CandleStore (PG)", () => {
       network: "solana-mainnet",
       poolAddress: "Pool111",
       timeframe: "15m",
-      timeframeMs: FIFTEEN_MIN_MS,
+
       closedCandleCutoffUnixMs: 5 * FIFTEEN_MIN_MS,
       limit: 100
     });
@@ -222,7 +222,7 @@ describe.skipIf(!process.env.DATABASE_URL)("CandleStore (PG)", () => {
       network: "solana-mainnet",
       poolAddress: "Pool111",
       timeframe: "15m",
-      timeframeMs: FIFTEEN_MIN_MS,
+
       closedCandleCutoffUnixMs: 25 * FIFTEEN_MIN_MS,
       limit: 5
     });
@@ -257,7 +257,7 @@ describe.skipIf(!process.env.DATABASE_URL)("CandleStore (PG)", () => {
       network: "solana-mainnet",
       poolAddress: "Pool111",
       timeframe: "15m",
-      timeframeMs: FIFTEEN_MIN_MS,
+
       closedCandleCutoffUnixMs: 10 * FIFTEEN_MIN_MS,
       limit: 100
     });

--- a/src/ledger/__tests__/candleStore.test.ts
+++ b/src/ledger/__tests__/candleStore.test.ts
@@ -96,6 +96,7 @@ describe.skipIf(!process.env.DATABASE_URL)("CandleStore (PG)", () => {
       network: "solana-mainnet",
       poolAddress: "Pool111",
       timeframe: "15m",
+      timeframeMs: FIFTEEN_MIN_MS,
       closedCandleCutoffUnixMs: 10 * FIFTEEN_MIN_MS,
       limit: 100
     });
@@ -166,6 +167,7 @@ describe.skipIf(!process.env.DATABASE_URL)("CandleStore (PG)", () => {
       network: "solana-mainnet",
       poolAddress: "Pool111",
       timeframe: "15m",
+      timeframeMs: FIFTEEN_MIN_MS,
       closedCandleCutoffUnixMs: 10 * FIFTEEN_MIN_MS,
       limit: 100
     });
@@ -190,6 +192,7 @@ describe.skipIf(!process.env.DATABASE_URL)("CandleStore (PG)", () => {
       network: "solana-mainnet",
       poolAddress: "Pool111",
       timeframe: "15m",
+      timeframeMs: FIFTEEN_MIN_MS,
       closedCandleCutoffUnixMs: 5 * FIFTEEN_MIN_MS,
       limit: 100
     });
@@ -219,6 +222,7 @@ describe.skipIf(!process.env.DATABASE_URL)("CandleStore (PG)", () => {
       network: "solana-mainnet",
       poolAddress: "Pool111",
       timeframe: "15m",
+      timeframeMs: FIFTEEN_MIN_MS,
       closedCandleCutoffUnixMs: 25 * FIFTEEN_MIN_MS,
       limit: 5
     });
@@ -253,6 +257,7 @@ describe.skipIf(!process.env.DATABASE_URL)("CandleStore (PG)", () => {
       network: "solana-mainnet",
       poolAddress: "Pool111",
       timeframe: "15m",
+      timeframeMs: FIFTEEN_MIN_MS,
       closedCandleCutoffUnixMs: 10 * FIFTEEN_MIN_MS,
       limit: 100
     });

--- a/src/ledger/__tests__/candlesWriter.test.ts
+++ b/src/ledger/__tests__/candlesWriter.test.ts
@@ -88,6 +88,7 @@ describe("writeCandles", () => {
       network: "solana-mainnet",
       poolAddress: "Pool111",
       timeframe: "15m",
+      timeframeMs: FIFTEEN_MIN_MS,
       closedCandleCutoffUnixMs: 10 * FIFTEEN_MIN_MS,
       limit: 100
     });

--- a/src/ledger/__tests__/candlesWriter.test.ts
+++ b/src/ledger/__tests__/candlesWriter.test.ts
@@ -88,7 +88,6 @@ describe("writeCandles", () => {
       network: "solana-mainnet",
       poolAddress: "Pool111",
       timeframe: "15m",
-      timeframeMs: FIFTEEN_MIN_MS,
       closedCandleCutoffUnixMs: 10 * FIFTEEN_MIN_MS,
       limit: 100
     });

--- a/src/ledger/candleStore.ts
+++ b/src/ledger/candleStore.ts
@@ -139,6 +139,7 @@ export class CandleStore {
   }
 
   async getLatestCandlesForFeed(params: GetLatestCandlesParams): Promise<CandleRow[]> {
+    const lookbackUnixMs = params.closedCandleCutoffUnixMs - params.limit * params.timeframeMs;
     const rows = await this.db.execute(sql`
       WITH latest_per_slot AS (
         SELECT unix_ms, open, high, low, close, volume,
@@ -153,6 +154,7 @@ export class CandleStore {
            AND pool_address = ${params.poolAddress}
            AND timeframe = ${params.timeframe}
            AND unix_ms <= ${params.closedCandleCutoffUnixMs}
+           AND unix_ms >= ${lookbackUnixMs}
       )
       SELECT unix_ms, open, high, low, close, volume
         FROM (

--- a/src/ledger/candleStore.ts
+++ b/src/ledger/candleStore.ts
@@ -139,7 +139,6 @@ export class CandleStore {
   }
 
   async getLatestCandlesForFeed(params: GetLatestCandlesParams): Promise<CandleRow[]> {
-    const lookbackUnixMs = params.closedCandleCutoffUnixMs - params.limit * params.timeframeMs;
     const rows = await this.db.execute(sql`
       WITH latest_per_slot AS (
         SELECT unix_ms, open, high, low, close, volume,
@@ -154,7 +153,6 @@ export class CandleStore {
            AND pool_address = ${params.poolAddress}
            AND timeframe = ${params.timeframe}
            AND unix_ms <= ${params.closedCandleCutoffUnixMs}
-           AND unix_ms >= ${lookbackUnixMs}
       )
       SELECT unix_ms, open, high, low, close, volume
         FROM (

--- a/src/ledger/candlesWriter.ts
+++ b/src/ledger/candlesWriter.ts
@@ -189,6 +189,7 @@ export const getLatestCandlesForFeed = (
   store: LedgerStore,
   params: GetLatestCandlesParams
 ): CandleRow[] => {
+  const lookbackUnixMs = params.closedCandleCutoffUnixMs - params.limit * params.timeframeMs;
   const rows = store.db
     .prepare(
       `WITH latest_per_slot AS (
@@ -201,6 +202,7 @@ export const getLatestCandlesForFeed = (
           WHERE symbol = ? AND source = ? AND network = ?
             AND pool_address = ? AND timeframe = ?
             AND unix_ms <= ?
+            AND unix_ms >= ?
        )
        SELECT unix_ms, open, high, low, close, volume
          FROM (
@@ -219,6 +221,7 @@ export const getLatestCandlesForFeed = (
       params.poolAddress,
       params.timeframe,
       params.closedCandleCutoffUnixMs,
+      lookbackUnixMs,
       params.limit
     ) as Array<{
     unix_ms: number;

--- a/src/ledger/candlesWriter.ts
+++ b/src/ledger/candlesWriter.ts
@@ -189,7 +189,6 @@ export const getLatestCandlesForFeed = (
   store: LedgerStore,
   params: GetLatestCandlesParams
 ): CandleRow[] => {
-  const lookbackUnixMs = params.closedCandleCutoffUnixMs - params.limit * params.timeframeMs;
   const rows = store.db
     .prepare(
       `WITH latest_per_slot AS (
@@ -202,8 +201,7 @@ export const getLatestCandlesForFeed = (
           WHERE symbol = ? AND source = ? AND network = ?
             AND pool_address = ? AND timeframe = ?
             AND unix_ms <= ?
-            AND unix_ms >= ?
-       )
+        )
        SELECT unix_ms, open, high, low, close, volume
          FROM (
            SELECT unix_ms, open, high, low, close, volume
@@ -221,7 +219,6 @@ export const getLatestCandlesForFeed = (
       params.poolAddress,
       params.timeframe,
       params.closedCandleCutoffUnixMs,
-      lookbackUnixMs,
       params.limit
     ) as Array<{
     unix_ms: number;


### PR DESCRIPTION
## Summary

Implements derived 1h regime reads by aggregating stored 15m candles at request time, rather than ingesting 1h candles separately. The store remains canonical (15m only); 1h is a view computed on-the-fly.

**Key changes:**
- Extended `RegimeReadTimeframe` to `"15m" | "1h"` while keeping `CandleIngestTimeframe` as `"15m"` only
- Added `aggregate15mTo1h` pure utility with telemetry (groups 15m candles into hourly buckets, validates alignment/completeness)
- Added `buildRegimeCandleReadPlan` discriminated union (`direct` | `derived` mode) for read-plan computation
- Rewrote `regimeCurrent` handler to orchestrate direct 15m reads vs derived 1h aggregation
- Extended `RegimeCurrentMetadata` with `sourceTimeframe`, `sourceCandleCount`, `derivedTimeframe?`, `aggregationVersion?`
- Distinct `CANDLES_NOT_FOUND` error codes (`NO_SOURCE_CANDLES` vs `NO_DERIVED_CANDLES_AFTER_AGGREGATION`)
- Bounded CTE query in candle store with `lookbackUnixMs` parameter
- Added config sanity runtime assertions and 5 new e2e tests for derived 1h path
- Updated OpenAPI and README for the widened timeframe enum
- Documented the pattern in `docs/solutions/best-practices/derived-candle-aggregation-pattern-2026-05-06.md`
- Refreshed two existing docs with post-m42 code references

## Validation

```
pnpm run typecheck && pnpm run test && pnpm run lint && pnpm run build
```

All pass: 405 tests, 59 skipped, typecheck clean, lint clean, build clean.

## Commits

| SHA | Description |
|-----|-------------|
| f8ee320 | Widen RegimeReadTimeframe and extend RegimeCurrentMetadata |
| 05870c5 | Accept timeframe=1h on /v1/regime/current |
| 6eb439e | Restore 1h MARKET_REGIME_CONFIG entry alongside 15m |
| 7da132f | Add pure aggregateCandles utility for 15m → 1h derivation |
| debd660 | Add regimeCandleReadPlan helper for source/derived cutoff math |
| f066720 | Thread caller-supplied metadata fields through buildRegimeCurrent |
| edb6427 | Orchestrate direct 15m and derived 1h reads in regimeCurrent handler |
| 56e17df | Cover derived 1h regime reads with end-to-end tests |
| 9d2b252 | Extract ONE_HOUR_MS and computeSourceCutoffUnixMs helper in e2e tests |
| ee7ae68 | Widen timeframe enum to [15m, 1h] in OpenAPI and README |
| bd2c7b4 | Compound derived 1h candle aggregation pattern in docs/solutions |
| 66f6622 | Address review findings — discriminated union, telemetry, error codes, CTE bound, config sanity |
| 7c14c48 | Refresh stale code references in candle migration and endpoint pattern docs after m42 |

Closes #42 