### PR TITLE
docs: fix README table formatting for prettier --check

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,10 +317,10 @@ When `DATABASE_URL` is set, the service connects to Postgres with `search_path=r
 
 The repo deploys as two Railway services from the same Dockerfile:
 
-| Service | `SERVICE_TYPE` | Purpose |
-| --- | --- | --- |
-| `regime-engine-web` | unset | Fastify HTTP service |
-| `regime-engine-gecko-collector` | `collector` | GeckoTerminal candle collector |
+| Service                         | `SERVICE_TYPE` | Purpose                        |
+| ------------------------------- | -------------- | ------------------------------ |
+| `regime-engine-web`             | unset          | Fastify HTTP service           |
+| `regime-engine-gecko-collector` | `collector`    | GeckoTerminal candle collector |
 
 The web service owns migrations. The collector skips migrations and posts through the HTTP ingest route.
 


### PR DESCRIPTION
## Summary
- `main`'s current README (introduced by #62/whichever PR landed the "align regime readme with evidence roadmap" rewrite) has a markdown table with unpadded columns, which fails `pnpm run format` (`prettier --check .`).
- Because CI checks out the merge of a PR branch into current `main` for `pull_request`-triggered workflows, this blocks the format step on **every** open PR right now — including PR #64, which never touches README.md.

## Fix
`pnpm exec prettier --write README.md` — table column alignment only, no content change.

## Test plan
- [x] `pnpm run format` passes locally after the fix