### PR TITLE
chore: exclude orchestrator run artifacts from prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,19 @@
+# AI orchestrator run bookkeeping — generated per-run inside .ai-worktrees/*,
+# not hand-authored project content, never meant to satisfy repo style rules.
+task-context-step-*.md
+quality-review-result*.json
+spec-review-result*.json
+fix-result.json
+plan-fix-result.json
+implement-step-history-*.json
+implementation-log.md
+validate/
+
+# Orchestrator run/scratch directories at the repo root (logs, prompts,
+# per-issue worktrees). Each worktree carries its own copy of this file, so
+# its own real source is still checked when validation runs with that
+# worktree as cwd; this only keeps the top-level checkout's format check
+# from tripping over the orchestrator's own bookkeeping.
+.ai-runs/
+.ai-tmp/
+.ai-worktrees/


### PR DESCRIPTION
## Summary
- Adds `.prettierignore` for the AI orchestrator's own per-run bookkeeping files, generated fresh inside `.ai-worktrees/<issue>/` on every run: `task-context-step-N.md`, `quality-review-result*.json`, `spec-review-result*.json`, `fix-result.json`, `plan-fix-result.json`, `implement-step-history-*.json`, `implementation-log.md`, `validate/`.
- Also ignores the repo-root scratch directories (`.ai-runs/`, `.ai-tmp/`, `.ai-worktrees/`) so a top-level `pnpm format` doesn't trip over them. Each per-issue worktree carries its own copy of `.prettierignore` at its own root, so real source inside a worktree is still fully checked when validation runs with that worktree as `cwd`.

## Context
Surfaced by opsclawd/regime-engine#64, which adds `pnpm format` to the orchestrator's validation set. Without this, `prettier --check .` fails on the orchestrator's own scratch files regardless of whether the actual generated code is correctly formatted.

## Test plan
- [x] `pnpm run format` passes cleanly on a worktree containing these artifact types