### PR TITLE
chore: cover the rest of the orchestrator's artifact filenames in prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,12 +1,34 @@
 # AI orchestrator run bookkeeping — generated per-run inside .ai-worktrees/*,
 # not hand-authored project content, never meant to satisfy repo style rules.
+# Sourced from the orchestrator's own artifact filenames (opsclawd/automation),
+# not just what's failed so far — avoids finding the rest one CI run at a time.
 task-context-step-*.md
 quality-review-result*.json
 spec-review-result*.json
+plan-review-arbiter-result.json
+arbiter-result.json
 fix-result.json
 plan-fix-result.json
+result.json
+result-iter-*.json
+review-fix-plan.json
+review-loop-history.json
+review-task-manifest.json
+review-triage.md
+reviews.json
+review.md
+code-review.md
+compound.md
+compound-draft.md
+comments.json
+issue.md
+issue-comments.md
+pr-summary.md
+verify-prompt.md
+task-manifest.json
 implement-step-history-*.json
 implementation-log.md
+validation-result.json
 validate/
 
 # Orchestrator run/scratch directories at the repo root (logs, prompts,


### PR DESCRIPTION
## Summary
- Follow-up to #66: that PR only covered filenames that had already tripped a run. The resumed issue-55 run hit `pnpm format` failures again right after #66 merged, on files #66 didn't anticipate (`result.json`, `implementation-log.md`, `implement-step-history-*.json`).
- Sourced the full set of orchestrator artifact filenames directly from `opsclawd/automation`'s source instead of discovering the rest one failed run at a time: `arbiter-result.json`, `plan-review-arbiter-result.json`, `result.json`, `result-iter-*.json`, `review-fix-plan.json`, `review-loop-history.json`, `review-task-manifest.json`, `review-triage.md`, `reviews.json`, `review.md`, `code-review.md`, `compound.md`, `compound-draft.md`, `comments.json`, `issue.md`, `issue-comments.md`, `pr-summary.md`, `verify-prompt.md`, `task-manifest.json`, `validation-result.json`.
- Deliberately left out generically-named artifacts (`output.json`, `run.json`, `data.json`) — too likely to collide with legitimate future project files at repo root.
- Left `plan.md`/`design.md`/`prompt.md`/`implement.md` alone — those are real, reviewed project docs per this repo's own convention (already tracked on `main`), not scratch, so they should stay formatted rather than ignored.

## Test plan
- [x] `pnpm run format` passes cleanly with these additions