### PR TITLE
fix: copy contracts/ into the Docker build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN pnpm install --frozen-lockfile
 
 COPY tsconfig.json tsconfig.build.json ./
 COPY src/ src/
+COPY contracts/ contracts/
 COPY scripts/ scripts/
 COPY drizzle/ drizzle/
 COPY drizzle.config.ts drizzle.config.ts


### PR DESCRIPTION
## Problem

Railway deploys of `main` fail since #69 (issue #58) merged:

```
src/contract/evidence/v1/validate.ts(6,22): error TS2307: Cannot find module
'../../../../contracts/evidence-bundle/v1/evidence-bundle.schema.json'
```

`validate.ts` imports the evidence-bundle JSON schema from the repo-root `contracts/` directory, but the Dockerfile's builder stage only copies `src/`, `scripts/`, `drizzle/`, and the tsconfigs — `contracts/` never enters the image, so `tsc` cannot resolve the import. Local builds pass because the directory is present in the working tree, which is why CI/validation never caught it.

## Fix

One line: `COPY contracts/ contracts/` in the builder stage. The production stage needs no change — `copyBuildAssets.mjs` already copies `contracts/evidence-bundle/v1` into `dist/contracts/`, and `dist` is copied wholesale, so the runtime import from compiled output resolves to `dist/contracts/...`.

## Verification

Reproduced locally in a clean worktree of `main`: with `contracts/` moved aside, `tsc -p tsconfig.build.json` fails with exactly the Railway error; restored, `pnpm run build` passes end-to-end and `dist/contracts/evidence-bundle/v1/` contains the schema, fixtures, and hash vectors. (Docker daemon unavailable on this host, so the image build itself will be exercised by Railway on merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)